### PR TITLE
Rb/new/support ihe gazelle xds metadata validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@
 *.ipr
 *.iws
 
+#Eclipse specific
+.classpath
+.project
+.settings/
+
 #Play Specific
 logs
 /project/project

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ RUNNING_PID
 
 #test repository deployment folder
 test/resources/repository
-repository/status-updates
+*/repository/status-updates/

--- a/gitb-core/src/main/java/com/gitb/types/DataTypeFactory.java
+++ b/gitb-core/src/main/java/com/gitb/types/DataTypeFactory.java
@@ -85,9 +85,6 @@ public class DataTypeFactory {
             case DataType.SCHEMA_DATA_TYPE:
                 data = new SchemaType();
                 break;
-            case DataType.BINARY_DATA_TYPE:
-                data = new BinaryType();
-                break;
             default:
                 if(isContainerType(type)){
                     String containerType = parseContainerType(type);

--- a/gitb-core/src/main/java/com/gitb/types/DataTypeFactory.java
+++ b/gitb-core/src/main/java/com/gitb/types/DataTypeFactory.java
@@ -82,6 +82,9 @@ public class DataTypeFactory {
             case DataType.SCHEMA_DATA_TYPE:
                 data = new SchemaType();
                 break;
+            case DataType.BINARY_DATA_TYPE:
+                data = new BinaryType();
+                break;
             default:
                 if(isContainerType(type)){
                     String containerType = parseContainerType(type);

--- a/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapMessagingHandler.java
+++ b/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapMessagingHandler.java
@@ -13,6 +13,7 @@ import com.gitb.messaging.model.SessionContext;
 import com.gitb.messaging.model.TransactionContext;
 import com.gitb.messaging.utils.MessagingHandlerUtils;
 import com.gitb.utils.ConfigurationUtils;
+
 import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +45,9 @@ public class SoapMessagingHandler extends AbstractMessagingHandler {
     public static final String SOAP_VERSION_1_2 = "1.2";
 
     public static final String SOAP_MESSAGE_CONTENT_TYPE = "text/xml";
+    
+    public static final String HTTP_CONTENT_TYPE_HEADER = "Content-Type";
+    public static final String SOAP_START_HEADER = "<root>";
 
     public static final String MODULE_DEFINITION_XML = "/soap-messaging-definition.xml";
 

--- a/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapMessagingHandler.java
+++ b/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapMessagingHandler.java
@@ -32,6 +32,9 @@ public class SoapMessagingHandler extends AbstractMessagingHandler {
     public static final String SOAP_HEADER_FIELD_NAME = "soap_header";
     public static final String SOAP_BODY_FIELD_NAME = "soap_body";
     public static final String SOAP_MESSAGE_FIELD_NAME = "soap_message";
+    public static final String SOAP_CONTENT_FIELD_NAME = "soap_content";
+    public static final String SOAP_ATTACHMENTS_FIELD_NAME = "soap_attachments";
+    public static final String SOAP_ATTACHMENTS_SIZE_FIELD_NAME = "soap_attachments_size";
 
     public static final String HTTP_URI_CONFIG_NAME = HttpMessagingHandler.HTTP_URI_CONFIG_NAME;
 

--- a/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapReceiver.java
+++ b/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapReceiver.java
@@ -1,5 +1,23 @@
 package com.gitb.messaging.layer.application.soap;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.xml.soap.AttachmentPart;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.MimeHeaders;
+import javax.xml.soap.Node;
+import javax.xml.soap.SOAPBody;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPHeader;
+import javax.xml.soap.SOAPMessage;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.gitb.core.Configuration;
 import com.gitb.messaging.Message;
 import com.gitb.messaging.layer.application.http.HttpMessagingHandler;
@@ -7,17 +25,13 @@ import com.gitb.messaging.layer.application.http.HttpReceiver;
 import com.gitb.messaging.model.SessionContext;
 import com.gitb.messaging.model.TransactionContext;
 import com.gitb.types.BinaryType;
+import com.gitb.types.DataType;
+import com.gitb.types.ListType;
 import com.gitb.types.MapType;
+import com.gitb.types.NumberType;
 import com.gitb.types.ObjectType;
 import com.gitb.types.StringType;
 import com.gitb.utils.ConfigurationUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.xml.soap.*;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.List;
 
 /**
  * Created by serbay on 9/23/14.
@@ -26,6 +40,7 @@ public class SoapReceiver extends HttpReceiver {
 
     private static final Logger logger = LoggerFactory.getLogger(SoapReceiver.class);
 
+    public static final String HTTP_CONTENT_TYPE_HEADER = "Content-Type";
 
     public SoapReceiver(SessionContext session, TransactionContext transaction) {
         super(session, transaction);
@@ -39,28 +54,74 @@ public class SoapReceiver extends HttpReceiver {
 
         MapType httpHeaders = (MapType) httpMessage.getFragments().get(HttpMessagingHandler.HTTP_HEADERS_FIELD_NAME);
 
-        BinaryType binaryContent = (BinaryType) httpMessage.getFragments().get(HttpMessagingHandler.HTTP_BODY_FIELD_NAME);
+        BinaryType binaryContent = (BinaryType) httpMessage.getFragments().get(
+                HttpMessagingHandler.HTTP_BODY_FIELD_NAME);
 
         byte[] content = (byte[]) binaryContent.getValue();
 
         InputStream inputStream = new ByteArrayInputStream(content);
 
-        //initialize the message factory according to given configuration in receive step
-        String soapVersion = ConfigurationUtils.getConfiguration(configurations, SoapMessagingHandler.SOAP_VERSION_CONFIG_NAME).getValue();
+        // initialize the message factory according to given configuration in
+        // receive step
+        String soapVersion = ConfigurationUtils.getConfiguration(configurations,
+                SoapMessagingHandler.SOAP_VERSION_CONFIG_NAME).getValue();
 
         MessageFactory messageFactory = null;
 
-        if(soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_1)) {
+        if (soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_1)) {
             messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
-        } else if(soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_2)) {
-            messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL); //double check
+        } else if (soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_2)) {
+            messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL); // double
+                                                                                          // check
         } else {
-            //will not execute here, already handled in SoapMessagingHandler
+            // will not execute here, already handled in SoapMessagingHandler
         }
 
-        SOAPMessage soapMessage = messageFactory.createMessage(null, inputStream);
+        // extract mimeHeaders if present
+        MimeHeaders mimeHeaders = new MimeHeaders();
+        StringType contentType = (StringType) httpHeaders.getItem(HTTP_CONTENT_TYPE_HEADER);
+        if (contentType != null) {
+            mimeHeaders.addHeader(HTTP_CONTENT_TYPE_HEADER, (String) contentType.getValue());
+        }
+
+        SOAPMessage soapMessage = messageFactory.createMessage(mimeHeaders, inputStream);
 
         logger.debug("Created soap message from the http message: " + soapMessage);
+
+        // manage attachment parts
+        ListType atts = new ListType(DataType.BINARY_DATA_TYPE);
+        Iterator<?> itAtts = soapMessage.getAttachments();
+        int sizeAtts = soapMessage.countAttachments();
+        logger.debug("Found {} attachment(s).", sizeAtts);
+
+        while (itAtts.hasNext()) {
+            Object att = null;
+
+            AttachmentPart itAtt = (AttachmentPart) itAtts.next();
+            logger.debug("Found an attachment: " + itAtt);
+            String typeAtt = itAtt.getContentType();
+            if (typeAtt.contains("text/")) {
+                String text = (String) itAtt.getContent();
+                att = text.getBytes();
+                // process text
+                logger.debug("Found an attachment of type text: " + text);
+            } else if (typeAtt.contains("image/")) {
+                att = IOUtils.toByteArray((InputStream) itAtt.getContent());
+                // process InputStream of image
+                logger.debug("Found an attachment of type image: " + atts);
+            } else if (typeAtt.contains("application/")) {
+                att = IOUtils.toByteArray((InputStream) itAtt.getContent());
+                // process InputStream of image
+                logger.debug("Found an attachment of type binary: " + atts);
+            }
+
+            // add to the list
+            if (att != null) {
+                BinaryType attObject = new BinaryType();
+                attObject.setValue(att);
+                atts.append(attObject);
+            }
+        }
 
         SOAPHeader soapHeader = soapMessage.getSOAPHeader();
         SOAPBody soapBody = soapMessage.getSOAPBody();
@@ -74,12 +135,38 @@ public class SoapReceiver extends HttpReceiver {
         ObjectType messageObject = new ObjectType();
         messageObject.setValue(soapMessage.getSOAPPart());
 
+        ObjectType contentObject = new ObjectType();
+        contentObject.setValue(getFirstElement(soapBody));
+
+        NumberType sizeAttsObject = new NumberType();
+        sizeAttsObject.setValue((double) sizeAtts);
+
         Message message = new Message();
         message.getFragments().put(SoapMessagingHandler.HTTP_HEADERS_FIELD_NAME, httpHeaders);
         message.getFragments().put(SoapMessagingHandler.SOAP_HEADER_FIELD_NAME, headerObject);
         message.getFragments().put(SoapMessagingHandler.SOAP_BODY_FIELD_NAME, bodyObject);
         message.getFragments().put(SoapMessagingHandler.SOAP_MESSAGE_FIELD_NAME, messageObject);
+        message.getFragments().put(SoapMessagingHandler.SOAP_CONTENT_FIELD_NAME, contentObject);
+        message.getFragments().put(SoapMessagingHandler.SOAP_ATTACHMENTS_FIELD_NAME, atts);
+        message.getFragments().put(SoapMessagingHandler.SOAP_ATTACHMENTS_SIZE_FIELD_NAME, sizeAttsObject);
 
         return message;
+    }
+
+    /**
+     * Extract the first element of the soapBody
+     * 
+     * @param soapBody
+     * @return
+     */
+    private Object getFirstElement(SOAPBody soapBody) {
+        Iterator<?> it = soapBody.getChildElements();
+        while (it.hasNext()) {
+            Node el = (Node) it.next();
+            if (el.getNodeType() == Node.ELEMENT_NODE) {
+                return el;
+            }
+        }
+        return null;
     }
 }

--- a/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapReceiver.java
+++ b/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapReceiver.java
@@ -38,135 +38,133 @@ import com.gitb.utils.ConfigurationUtils;
  */
 public class SoapReceiver extends HttpReceiver {
 
-    private static final Logger logger = LoggerFactory.getLogger(SoapReceiver.class);
+	private static final Logger logger = LoggerFactory.getLogger(SoapReceiver.class);
 
-    public static final String HTTP_CONTENT_TYPE_HEADER = "Content-Type";
+	public SoapReceiver(SessionContext session, TransactionContext transaction) {
+		super(session, transaction);
+	}
 
-    public SoapReceiver(SessionContext session, TransactionContext transaction) {
-        super(session, transaction);
-    }
+	@Override
+	public Message receive(List<Configuration> configurations) throws Exception {
+		Message httpMessage = super.receive(configurations);
 
-    @Override
-    public Message receive(List<Configuration> configurations) throws Exception {
-        Message httpMessage = super.receive(configurations);
+		logger.debug("Received http message");
 
-        logger.debug("Received http message");
+		MapType httpHeaders = (MapType) httpMessage.getFragments().get(HttpMessagingHandler.HTTP_HEADERS_FIELD_NAME);
 
-        MapType httpHeaders = (MapType) httpMessage.getFragments().get(HttpMessagingHandler.HTTP_HEADERS_FIELD_NAME);
+		BinaryType binaryContent = (BinaryType) httpMessage.getFragments().get(
+				HttpMessagingHandler.HTTP_BODY_FIELD_NAME);
 
-        BinaryType binaryContent = (BinaryType) httpMessage.getFragments().get(
-                HttpMessagingHandler.HTTP_BODY_FIELD_NAME);
+		byte[] content = (byte[]) binaryContent.getValue();
 
-        byte[] content = (byte[]) binaryContent.getValue();
+		InputStream inputStream = new ByteArrayInputStream(content);
 
-        InputStream inputStream = new ByteArrayInputStream(content);
+		// initialize the message factory according to given configuration in
+		// receive step
+		String soapVersion = ConfigurationUtils.getConfiguration(configurations,
+				SoapMessagingHandler.SOAP_VERSION_CONFIG_NAME).getValue();
 
-        // initialize the message factory according to given configuration in
-        // receive step
-        String soapVersion = ConfigurationUtils.getConfiguration(configurations,
-                SoapMessagingHandler.SOAP_VERSION_CONFIG_NAME).getValue();
+		MessageFactory messageFactory = null;
 
-        MessageFactory messageFactory = null;
+		if (soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_1)) {
+			messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
+		} else if (soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_2)) {
+			messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL); // double
+																						  // check
+		} else {
+			// will not execute here, already handled in SoapMessagingHandler
+		}
 
-        if (soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_1)) {
-            messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
-        } else if (soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_2)) {
-            messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL); // double
-                                                                                          // check
-        } else {
-            // will not execute here, already handled in SoapMessagingHandler
-        }
+		// extract mimeHeaders if present
+		MimeHeaders mimeHeaders = new MimeHeaders();
+		StringType contentType = (StringType) httpHeaders.getItem(SoapMessagingHandler.HTTP_CONTENT_TYPE_HEADER);
+		if (contentType != null) {
+			mimeHeaders.addHeader(SoapMessagingHandler.HTTP_CONTENT_TYPE_HEADER, (String) contentType.getValue());
+		}
 
-        // extract mimeHeaders if present
-        MimeHeaders mimeHeaders = new MimeHeaders();
-        StringType contentType = (StringType) httpHeaders.getItem(HTTP_CONTENT_TYPE_HEADER);
-        if (contentType != null) {
-            mimeHeaders.addHeader(HTTP_CONTENT_TYPE_HEADER, (String) contentType.getValue());
-        }
+		SOAPMessage soapMessage = messageFactory.createMessage(mimeHeaders, inputStream);
 
-        SOAPMessage soapMessage = messageFactory.createMessage(mimeHeaders, inputStream);
+		logger.debug("Created soap message from the http message: " + soapMessage);
 
-        logger.debug("Created soap message from the http message: " + soapMessage);
+		// manage attachment parts
+		ListType atts = new ListType(DataType.BINARY_DATA_TYPE);
+		Iterator<?> itAtts = soapMessage.getAttachments();
+		int sizeAtts = soapMessage.countAttachments();
+		logger.debug("Found {} attachment(s).", sizeAtts);
 
-        // manage attachment parts
-        ListType atts = new ListType(DataType.BINARY_DATA_TYPE);
-        Iterator<?> itAtts = soapMessage.getAttachments();
-        int sizeAtts = soapMessage.countAttachments();
-        logger.debug("Found {} attachment(s).", sizeAtts);
+		while (itAtts.hasNext()) {
+			Object att = null;
 
-        while (itAtts.hasNext()) {
-            Object att = null;
+			AttachmentPart itAtt = (AttachmentPart) itAtts.next();
+			logger.debug("Found an attachment: " + itAtt);
+			String typeAtt = itAtt.getContentType();
+			if (typeAtt.contains("text/")) {
+				String text = (String) itAtt.getContent();
+				att = text.getBytes();
+				// process text
+				logger.debug("Found an attachment of type text: " + text);
+			} else if (typeAtt.contains("image/")) {
+				att = IOUtils.toByteArray((InputStream) itAtt.getContent());
+				// process InputStream of image
+				logger.debug("Found an attachment of type image: " + atts);
+			} else if (typeAtt.contains("application/")) {
+				att = IOUtils.toByteArray((InputStream) itAtt.getContent());
+				// process InputStream of image
+				logger.debug("Found an attachment of type binary: " + atts);
+			}
 
-            AttachmentPart itAtt = (AttachmentPart) itAtts.next();
-            logger.debug("Found an attachment: " + itAtt);
-            String typeAtt = itAtt.getContentType();
-            if (typeAtt.contains("text/")) {
-                String text = (String) itAtt.getContent();
-                att = text.getBytes();
-                // process text
-                logger.debug("Found an attachment of type text: " + text);
-            } else if (typeAtt.contains("image/")) {
-                att = IOUtils.toByteArray((InputStream) itAtt.getContent());
-                // process InputStream of image
-                logger.debug("Found an attachment of type image: " + atts);
-            } else if (typeAtt.contains("application/")) {
-                att = IOUtils.toByteArray((InputStream) itAtt.getContent());
-                // process InputStream of image
-                logger.debug("Found an attachment of type binary: " + atts);
-            }
+			// add to the list
+			if (att != null) {
+				BinaryType attObject = new BinaryType();
+				attObject.setValue(att);
+				atts.append(attObject);
+			}
+		}
 
-            // add to the list
-            if (att != null) {
-                BinaryType attObject = new BinaryType();
-                attObject.setValue(att);
-                atts.append(attObject);
-            }
-        }
+		SOAPHeader soapHeader = soapMessage.getSOAPHeader();
+		SOAPBody soapBody = soapMessage.getSOAPBody();
 
-        SOAPHeader soapHeader = soapMessage.getSOAPHeader();
-        SOAPBody soapBody = soapMessage.getSOAPBody();
+		ObjectType headerObject = new ObjectType();
+		headerObject.setValue(soapHeader);
 
-        ObjectType headerObject = new ObjectType();
-        headerObject.setValue(soapHeader);
+		ObjectType bodyObject = new ObjectType();
+		bodyObject.setValue(soapBody);
 
-        ObjectType bodyObject = new ObjectType();
-        bodyObject.setValue(soapBody);
+		ObjectType messageObject = new ObjectType();
+		messageObject.setValue(soapMessage.getSOAPPart());
 
-        ObjectType messageObject = new ObjectType();
-        messageObject.setValue(soapMessage.getSOAPPart());
+		ObjectType contentObject = new ObjectType();
+		contentObject.setValue(getFirstElement(soapBody));
 
-        ObjectType contentObject = new ObjectType();
-        contentObject.setValue(getFirstElement(soapBody));
+		NumberType sizeAttsObject = new NumberType();
+		sizeAttsObject.setValue((double) sizeAtts);
 
-        NumberType sizeAttsObject = new NumberType();
-        sizeAttsObject.setValue((double) sizeAtts);
+		Message message = new Message();
+		message.getFragments().put(SoapMessagingHandler.HTTP_HEADERS_FIELD_NAME, httpHeaders);
+		message.getFragments().put(SoapMessagingHandler.SOAP_HEADER_FIELD_NAME, headerObject);
+		message.getFragments().put(SoapMessagingHandler.SOAP_BODY_FIELD_NAME, bodyObject);
+		message.getFragments().put(SoapMessagingHandler.SOAP_MESSAGE_FIELD_NAME, messageObject);
+		message.getFragments().put(SoapMessagingHandler.SOAP_CONTENT_FIELD_NAME, contentObject);
+		message.getFragments().put(SoapMessagingHandler.SOAP_ATTACHMENTS_FIELD_NAME, atts);
+		message.getFragments().put(SoapMessagingHandler.SOAP_ATTACHMENTS_SIZE_FIELD_NAME, sizeAttsObject);
 
-        Message message = new Message();
-        message.getFragments().put(SoapMessagingHandler.HTTP_HEADERS_FIELD_NAME, httpHeaders);
-        message.getFragments().put(SoapMessagingHandler.SOAP_HEADER_FIELD_NAME, headerObject);
-        message.getFragments().put(SoapMessagingHandler.SOAP_BODY_FIELD_NAME, bodyObject);
-        message.getFragments().put(SoapMessagingHandler.SOAP_MESSAGE_FIELD_NAME, messageObject);
-        message.getFragments().put(SoapMessagingHandler.SOAP_CONTENT_FIELD_NAME, contentObject);
-        message.getFragments().put(SoapMessagingHandler.SOAP_ATTACHMENTS_FIELD_NAME, atts);
-        message.getFragments().put(SoapMessagingHandler.SOAP_ATTACHMENTS_SIZE_FIELD_NAME, sizeAttsObject);
+		return message;
+	}
 
-        return message;
-    }
-
-    /**
-     * Extract the first element of the soapBody
-     * 
-     * @param soapBody
-     * @return
-     */
-    private Object getFirstElement(SOAPBody soapBody) {
-        Iterator<?> it = soapBody.getChildElements();
-        while (it.hasNext()) {
-            Node el = (Node) it.next();
-            if (el.getNodeType() == Node.ELEMENT_NODE) {
-                return el;
-            }
-        }
-        return null;
-    }
+	/**
+	 * Extract the first element of the soapBody
+	 * 
+	 * @param soapBody
+	 * @return
+	 */
+	private Object getFirstElement(SOAPBody soapBody) {
+		Iterator<?> it = soapBody.getChildElements();
+		while (it.hasNext()) {
+			Node el = (Node) it.next();
+			if (el.getNodeType() == Node.ELEMENT_NODE) {
+				return el;
+			}
+		}
+		return null;
+	}
 }

--- a/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapSender.java
+++ b/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapSender.java
@@ -105,14 +105,14 @@ public class SoapSender extends HttpSender {
 		// add attachments
 		MapType attsObject = getAttachments(message);
 		if (attsObject != null) {
-		    Map<String, DataType> atts = ((Map<String, DataType>) attsObject.getValue());
-    		for (String contentId : atts.keySet()) {
-    		    ByteArrayDataSource ds = new ByteArrayDataSource(atts.get(contentId).serializeByDefaultEncoding(), "application/octet-stream");
-    		    DataHandler dh = new DataHandler(ds);
-                AttachmentPart ap = soapMessage.createAttachmentPart(dh);
-                ap.setContentId(contentId);
-                soapMessage.addAttachmentPart(ap);
-    		}
+			Map<String, DataType> atts = ((Map<String, DataType>) attsObject.getValue());
+			for (String contentId : atts.keySet()) {
+				ByteArrayDataSource ds = new ByteArrayDataSource(atts.get(contentId).serializeByDefaultEncoding(), "application/octet-stream");
+				DataHandler dh = new DataHandler(ds);
+				AttachmentPart ap = soapMessage.createAttachmentPart(dh);
+				ap.setContentId(contentId);
+				soapMessage.addAttachmentPart(ap);
+			}
 		}
 
 		return soapMessage;
@@ -125,10 +125,10 @@ public class SoapSender extends HttpSender {
 	}
 	
 	private MapType getAttachments(Message message) {
-	    MapType object = (MapType) message.getFragments().get(SoapMessagingHandler.SOAP_ATTACHMENTS_FIELD_NAME);
+		MapType object = (MapType) message.getFragments().get(SoapMessagingHandler.SOAP_ATTACHMENTS_FIELD_NAME);
 
-        return object;
-    }
+		return object;
+	}
 
 
 	private String getCharsetEncoding(List<Configuration> configurations, Message message) {

--- a/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapSender.java
+++ b/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapSender.java
@@ -72,11 +72,17 @@ public class SoapSender extends HttpSender {
 		
 		// compute Content-Type
 		String soapContentType = "start-info=\"application/soap+xml\"; start=\"" + SoapMessagingHandler.SOAP_START_HEADER + "\";";
-		String[] soapHeader = soapMessage.getMimeHeaders().getHeader(SoapMessagingHandler.HTTP_CONTENT_TYPE_HEADER);
-		if (soapMessage.countAttachments() != 0 && soapHeader != null) {
+		String[] soapHeaders = soapMessage.getMimeHeaders().getHeader(SoapMessagingHandler.HTTP_CONTENT_TYPE_HEADER);
+		if (soapMessage.countAttachments() != 0 && soapHeaders != null) {
 			// add MTOM specific Content-Type
-			soapContentType = "multipart/related; type=\"application/xop+xml\"; " 
-					+ soapHeader[0].substring(soapHeader[0].indexOf("boundary")) + "; " + soapContentType;
+			soapContentType = "multipart/related; type=\"application/xop+xml\"; " + soapContentType;
+			
+			// add boundary
+			for (String soapHeader : soapHeaders[0].split(";")) {
+				if (soapHeader.contains("boundary")) {
+					soapContentType += soapHeader + ";";
+				}
+			}
 		}
 		
 		// add Content-Type

--- a/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapSender.java
+++ b/gitb-messaging/src/main/java/com/gitb/messaging/layer/application/soap/SoapSender.java
@@ -10,6 +10,7 @@ import com.gitb.types.BinaryType;
 import com.gitb.types.DataType;
 import com.gitb.types.MapType;
 import com.gitb.types.ObjectType;
+import com.gitb.types.StringType;
 import com.gitb.utils.ConfigurationUtils;
 
 import org.slf4j.Logger;
@@ -58,7 +59,7 @@ public class SoapSender extends HttpSender {
 
 		logger.debug("Sent soap message");
 
-        return httpMessage;
+		return httpMessage;
 	}
 
 	protected Message constructHttpMessageFromSoapMessage(List<Configuration> configurations, Message message, SOAPMessage soapMessage) throws IOException, SOAPException {
@@ -68,6 +69,24 @@ public class SoapSender extends HttpSender {
 		byte[] binaryMessage = outputStream.toByteArray();
 
 		Message httpMessage = new Message();
+		
+		// compute Content-Type
+		String soapContentType = "start-info=\"application/soap+xml\"; start=\"" + SoapMessagingHandler.SOAP_START_HEADER + "\";";
+		String[] soapHeader = soapMessage.getMimeHeaders().getHeader(SoapMessagingHandler.HTTP_CONTENT_TYPE_HEADER);
+		if (soapMessage.countAttachments() != 0 && soapHeader != null) {
+			// add MTOM specific Content-Type
+			soapContentType = "multipart/related; type=\"application/xop+xml\"; " 
+					+ soapHeader[0].substring(soapHeader[0].indexOf("boundary")) + "; " + soapContentType;
+		}
+		
+		// add Content-Type
+		MapType soapHeaderType = new MapType();
+		soapHeaderType.addItem(SoapMessagingHandler.HTTP_CONTENT_TYPE_HEADER, new StringType(soapContentType));
+		httpMessage
+			.getFragments()
+			.put(SoapMessagingHandler.HTTP_HEADERS_FIELD_NAME, soapHeaderType);
+		
+		// add header from parameter 
 		if(message.getFragments().containsKey(SoapMessagingHandler.HTTP_HEADERS_FIELD_NAME)) {
 			httpMessage
 				.getFragments()
@@ -85,22 +104,25 @@ public class SoapSender extends HttpSender {
 	}
 
 	protected SOAPMessage constructSoapMessage(List<Configuration> configurations, Message message) throws SOAPException, IOException {
-        //initialize the message factory according to given configuration in send step
-        String soapVersion = ConfigurationUtils.getConfiguration(configurations, SoapMessagingHandler.SOAP_VERSION_CONFIG_NAME).getValue();
+		//initialize the message factory according to given configuration in send step
+		String soapVersion = ConfigurationUtils.getConfiguration(configurations, SoapMessagingHandler.SOAP_VERSION_CONFIG_NAME).getValue();
 
-        MessageFactory messageFactory = null;
+		MessageFactory messageFactory = null;
 
-        if(soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_1)) {
-            messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
-        } else if(soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_2)) {
-            messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL); //double check
-        } else {
-            //will not execute here, already handled in SoapMessagingHandler
-        }
+		if(soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_1)) {
+			messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL);
+		} else if(soapVersion.contentEquals(SoapMessagingHandler.SOAP_VERSION_1_2)) {
+			messageFactory = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL); //double check
+		} else {
+			//will not execute here, already handled in SoapMessagingHandler
+		}
 
 		ObjectType messageNode = getMessageNode(configurations, message);
-
+		 
 		SOAPMessage soapMessage = messageFactory.createMessage(null, new ByteArrayInputStream(messageNode.serializeByDefaultEncoding()));
+		
+		// add a content-id
+		soapMessage.getSOAPPart().setContentId(SoapMessagingHandler.SOAP_START_HEADER);
 		
 		// add attachments
 		MapType attsObject = getAttachments(message);
@@ -114,7 +136,7 @@ public class SoapSender extends HttpSender {
 				soapMessage.addAttachmentPart(ap);
 			}
 		}
-
+		
 		return soapMessage;
 	}
 

--- a/gitb-messaging/src/main/resources/soap-messaging-definition.xml
+++ b/gitb-messaging/src/main/resources/soap-messaging-definition.xml
@@ -9,12 +9,16 @@
 	<inputs>
 		<param name="http_headers" type="map" use="O"/>
 		<param name="soap_message" type="object"/>
+		<param name="soap_attachments" type="map" use="O"/>
 	</inputs>
 	<outputs>
 		<param name="http_headers" type="map" use="O"/>
 		<param name="soap_header" type="object"/>
 		<param name="soap_body" type="object"/>
 		<param name="soap_message" type="object"/>
+		<param name="soap_content" type="object"/>
+		<param name="soap_attachments" type="list"/>
+		<param name="soap_attachments_size" type="number"/>
 	</outputs>
 	<actorConfigs>
 		<param name="network.host" desc="Hostname/IP address for the actor"/>

--- a/gitb-messaging/src/main/resources/soap-messaging-definition.xml
+++ b/gitb-messaging/src/main/resources/soap-messaging-definition.xml
@@ -17,8 +17,8 @@
 		<param name="soap_body" type="object"/>
 		<param name="soap_message" type="object"/>
 		<param name="soap_content" type="object"/>
-		<param name="soap_attachments" type="list"/>
-		<param name="soap_attachments_size" type="number"/>
+		<param name="soap_attachments" type="map" use="O"/>
+		<param name="soap_attachments_size" type="number" use="O"/>
 	</outputs>
 	<actorConfigs>
 		<param name="network.host" desc="Hostname/IP address for the actor"/>

--- a/gitb-remote-modules/src/main/resources/modules/validation/ihe-gazelle-xdsmetadata-validator-definition.xml
+++ b/gitb-remote-modules/src/main/resources/modules/validation/ihe-gazelle-xdsmetadata-validator-definition.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<module xmlns="http://www.gitb.com/core/v1/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        id="XDSMetadataValidator" uri="urn:com:gitb:validation:ihe:gazelle:XDSMetadataValidator"
+        xsi:type="ValidationModule" isRemote="true" serviceLocation="http://localhost:9091/service/ValidationService">
+    <metadata>
+        <name>Gazelle XDS Metadata Validation</name>
+        <version>1.0</version>
+    </metadata>
+    <inputs>
+        <param type="object" use="R" name="xmldocument" desc="XML Document to be validated" />
+        <param type="string" use="R" name="validatorname" desc="Name of the validator to invoke" />
+    </inputs>
+</module>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/IHEXDSbTestSuite.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/IHEXDSbTestSuite.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns="http://www.gitb.com/tdl/v1/" xmlns:gitb="http://www.gitb.com/core/v1/">
+	<metadata>
+		<gitb:name>IHE_XDSb_SharingOfDocument</gitb:name>
+		<gitb:version>0.1</gitb:version>
+	</metadata>
+	<actors>
+		<gitb:actor id="DocumentSource">
+			<gitb:name>Document Source</gitb:name>
+			<gitb:desc>Is the producer and publisher of documents. It is responsible for sending documents to a Document Repository Actor. It also supplies metadata to the Document Repository Actor for subsequent registration of the documents with the Document Registry Actor.</gitb:desc>
+			<gitb:endpoint name="soap">
+				<gitb:config name="network.host" />
+				<gitb:config name="network.port" />
+				<gitb:config name="patient.id"/>
+			</gitb:endpoint>
+		</gitb:actor>
+        <gitb:actor id="DocumentRepository">
+            <gitb:name>Document Repository</gitb:name>
+            <gitb:desc>Is responsible for both the persistent storage of these documents as well as for their registration with the appropriate Document Registry. It assigns a uniqueId to documents for subsequent retrieval by a Document Consumer.</gitb:desc>
+            <gitb:endpoint name="soap">
+                <gitb:config name="network.host" />
+                <gitb:config name="network.port" />
+                <gitb:config name="http.uri"/>
+                <gitb:config name="patient.id"/>
+            </gitb:endpoint>
+        </gitb:actor>
+        <gitb:actor id="DocumentRegistry">
+            <gitb:name>Document Registry</gitb:name>
+            <gitb:desc>Maintains metadata about each registered document in a document entry. This includes a link to the Document in the Repository where it is stored. The Document Registry responds to queries from Document Consumer actors about documents meeting specific criteria. It also enforces some healthcare specific technical policies at the time of document registration. </gitb:desc>
+            <gitb:endpoint name="http">
+                <gitb:config name="network.host" />
+                <gitb:config name="network.port" />
+            </gitb:endpoint>
+        </gitb:actor>
+        <gitb:actor id="DocumentConsumer">
+            <gitb:name>Document Consumer</gitb:name>
+            <gitb:desc>Queries a Document Registry Actor for documents meeting certain criteria, and retrieves selected documents from one or more Document Repository actors</gitb:desc>
+            <gitb:endpoint name="soap">
+                <gitb:config name="network.host" />
+                <gitb:config name="network.port" />
+                <gitb:config name="soap.address"/>
+            </gitb:endpoint>
+        </gitb:actor>
+	</actors>
+	<testcase id="DocumentSource-IHE-ProvideAndRegister" />
+    <testcase id="DocumentRepository-IHE-ProvideAndRegister" />
+</testsuite>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/XDS/XDS.b_DocumentRepository.xsd
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/XDS/XDS.b_DocumentRepository.xsd
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XML Spy v4.4 U (http://www.xmlspy.com) by 4.0 Concurrent Multi IDE for 5 users (Mitra Imaging Inc.) -->
+<xs:schema targetNamespace="urn:ihe:iti:xds-b:2007" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:ihe:iti:xds-b:2007" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" schemaLocation="../../OASIS/ebRS/rs.xsd"/>
+	<xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" schemaLocation="../../OASIS/ebRS/rim.xsd"/>
+	<xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" schemaLocation="../../OASIS/ebRS/lcm.xsd"/>
+	<xs:import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" schemaLocation="../../OASIS/ebRS/query.xsd"/>
+	<xs:complexType name="RetrieveDocumentSetRequestType">
+		<xs:sequence>
+			<xs:element name="DocumentRequest" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="HomeCommunityId" type="rim:LongName" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>This corresponds to the home attribute of the Identifiable class in regrep RIM (regrep-rim-3.0-os.pdf, page 20)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RepositoryUniqueId" type="rim:LongName">
+							<xs:annotation>
+								<xs:documentation>This is the XDSDocumentEntry.repositoryUniqueId attribute in the XDS metadata</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="DocumentUniqueId" type="rim:LongName">
+							<xs:annotation>
+								<xs:documentation>This is the XDSDocumentEntry.uniqueId attribute in the XDS metadata</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RetrieveDocumentSetResponseType">
+		<xs:sequence>
+			<xs:element ref="rs:RegistryResponse"/>
+			<xs:sequence minOccurs="0">
+				<xs:element name="DocumentResponse" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="HomeCommunityId" type="rim:LongName" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>This corresponds to the home attribute of the Identifiable class in regrep RIM (regrep-rim-3.0-os.pdf, page 20)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="RepositoryUniqueId" type="rim:LongName">
+								<xs:annotation>
+									<xs:documentation>This is the XDSDocumentEntry.repositoryUniqueId attribute in the XDS metadata</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="DocumentUniqueId" type="rim:LongName">
+								<xs:annotation>
+									<xs:documentation>This is the XDSDocumentEntry.uniqueId attribute in the XDS metadata</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="mimeType" type="rim:LongName"/>
+							<xs:element name="Document" type="xs:base64Binary"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="RetrieveDocumentSetRequest" type="RetrieveDocumentSetRequestType"/>
+	<xs:element name="RetrieveDocumentSetResponse" type="RetrieveDocumentSetResponseType"/>
+	<xs:complexType name="ProvideAndRegisterDocumentSetRequestType">
+		<xs:sequence>
+			<xs:element ref="lcm:SubmitObjectsRequest"/>
+			<xs:sequence minOccurs="0">
+				<xs:element name="Document" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:base64Binary">
+								<xs:attribute name="id" type="xs:anyURI" use="required">
+									<xs:annotation>
+										<xs:documentation>This corresponds to the ExtrinsicObject id in the eb RIM metadata a provides a linkage between the actual document data and its metadata</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="ProvideAndRegisterDocumentSetRequest" type="ProvideAndRegisterDocumentSetRequestType"/>
+</xs:schema>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-docrepo-template.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-docrepo-template.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"
+                  xmlns:wsa="http://www.w3.org/2005/08/addressing">
+   <soapenv:Header>
+      <wsa:Action>urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-bResponse</wsa:Action>
+      <wsa:RelatesTo>urn:uuid:db12102e-7f10-4a7e-9db1-85e23b032337</wsa:RelatesTo>
+   </soapenv:Header>
+   <soapenv:Body>
+      <rs:RegistryResponse xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0"
+                           status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"/>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-xdsb-request-ITI41.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-xdsb-request-ITI41.xml
@@ -211,7 +211,7 @@
             </rim:RegistryObjectList>
          </lcm:SubmitObjectsRequest>
          <xdsb:Document id="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49">
-            <xop:Include href="cid:1.urn:uuid:18D13225BA9D47DBBB2B53FBA3A42A49"/>
+            <xop:Include href="attachment1"/>
          </xdsb:Document>
       </xdsb:ProvideAndRegisterDocumentSetRequest>
    </s:Body>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-xdsb-request-ITI41.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-xdsb-request-ITI41.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:a="http://www.w3.org/2005/08/addressing"
+            xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+   <s:Header>
+      <a:Action s:mustUnderstand="1">urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b</a:Action>
+      <a:MessageID>urn:uuid:a2808b83-aab0-41bd-b42e-39ef0b96fbcb</a:MessageID>
+      <a:ReplyTo>
+         <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
+      </a:ReplyTo>
+      <a:To s:mustUnderstand="1">http://ihexds.nist.gov:12090/tf6/services/xdsrepositoryb?wsdl</a:To>
+   </s:Header>
+   <s:Body>
+      <xdsb:ProvideAndRegisterDocumentSetRequest xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0"
+                                                 xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                                                 xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0"
+                                                 xmlns:xdsb="urn:ihe:iti:xds-b:2007"
+                                                 xmlns:xop="http://www.w3.org/2004/08/xop/include">
+         <lcm:SubmitObjectsRequest>
+            <rim:RegistryObjectList>
+               <rim:RegistryPackage id="urn:uuid:a20ff1a4-3820-4832-9582-3bde4a74658c"
+                                    objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:RegistryPackage">
+                  <rim:Slot name="submissionTime">
+                    <rim:ValueList>
+                        <rim:Value>20150514101328</rim:Value>
+                    </rim:ValueList>
+                  </rim:Slot>
+                  <rim:Name>
+                    <rim:LocalizedString value="XDS Submission Set"/>
+                  </rim:Name>
+                  <rim:Classification classificationScheme="urn:uuid:aa543740-bdda-424e-8c96-df4873be8500"
+                                      classifiedObject="urn:uuid:a20ff1a4-3820-4832-9582-3bde4a74658c"
+                                      id="urn:uuid:32279ac1-06a1-427f-aedd-cdb449f0efe2"
+                                      nodeRepresentation="11488-4"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification">
+                    <rim:Slot name="codingScheme">
+                        <rim:ValueList>
+                            <rim:Value>2.16.840.1.113883.6.1</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="Consultation Note"/>
+                    </rim:Name>
+                  </rim:Classification>
+                  <rim:Classification classificationNode="urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd"
+                                      classifiedObject="urn:uuid:a20ff1a4-3820-4832-9582-3bde4a74658c"
+                                      id="urn:uuid:0f16bc09-6a9c-4046-bf10-95536006ed9a"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification"/>
+                  <rim:ExternalIdentifier id="urn:uuid:5f5705db-f31c-4603-b359-6bf2b30f5610"
+                                          identificationScheme="urn:uuid:554ac39e-e3fe-47fe-b233-965d2a147832"
+                                          objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"
+                                          registryObject="urn:uuid:a20ff1a4-3820-4832-9582-3bde4a74658c"
+                                          value="1.3.6.1.4.1.21367.2012.2.1.1">
+                    <rim:Name>
+                        <rim:LocalizedString value="XDSSubmissionSet.sourceId"/>
+                    </rim:Name>
+                  </rim:ExternalIdentifier>
+                  <rim:ExternalIdentifier id="urn:uuid:092faf7f-7cb6-481f-a6ae-0f9ecd690321"
+                                          identificationScheme="urn:uuid:96fdda7c-d067-4183-912e-bf5ee74998a8"
+                                          objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"
+                                          registryObject="urn:uuid:a20ff1a4-3820-4832-9582-3bde4a74658c"
+                                          value="1.3.6.1.4.1.12559.11.1.2.2.1.1.4.36756">
+                    <rim:Name>
+                        <rim:LocalizedString value="XDSSubmissionSet.uniqueId"/>
+                    </rim:Name>
+                  </rim:ExternalIdentifier>
+                  <rim:ExternalIdentifier id="47a1ca6f-66a5-4bc4-a39c-bed1e0d713e7"
+                                          identificationScheme="urn:uuid:6b5aea1a-874d-4603-a4bc-96a0a7b38446"
+                                          objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"
+                                          registryObject="urn:uuid:a20ff1a4-3820-4832-9582-3bde4a74658c"
+                                          value="9be1413171a8492^^^&amp;1.3.6.1.4.1.21367.2005.13.20.1000&amp;ISO">
+                    <rim:Name>
+                        <rim:LocalizedString value="XDSSubmissionSet.patientId"/>
+                    </rim:Name>
+                  </rim:ExternalIdentifier>
+               </rim:RegistryPackage>
+               <rim:ExtrinsicObject id="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                    mimeType="text/plain"
+                                    objectType="urn:uuid:7edca82f-054d-47f2-a032-9b2a5b5186c1"
+                                    status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">
+                  <rim:Slot name="creationTime">
+                    <rim:ValueList>
+                        <rim:Value>20150514095600</rim:Value>
+                    </rim:ValueList>
+                  </rim:Slot>
+                  <rim:Slot name="languageCode">
+                    <rim:ValueList>
+                        <rim:Value>en-us</rim:Value>
+                    </rim:ValueList>
+                  </rim:Slot>
+                  <rim:Slot name="sourcePatientId">
+                    <rim:ValueList>
+                        <rim:Value>9be1413171a8492^^^&amp;1.3.6.1.4.1.21367.2005.13.20.1000&amp;ISO</rim:Value>
+                    </rim:ValueList>
+                  </rim:Slot>
+                  <rim:Name>
+                    <rim:LocalizedString value="XDSDocument Entry 1"/>
+                  </rim:Name>
+                  <rim:Classification classificationScheme="urn:uuid:41a5887f-8865-4c09-adf7-e362475b143a"
+                                      classifiedObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                      id="urn:uuid:b25b3cd6-f2f7-451f-947c-cd422cc7c8b3"
+                                      nodeRepresentation="DEMO-Pt Mgmt"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification">
+                    <rim:Slot name="codingScheme">
+                        <rim:ValueList>
+                            <rim:Value>1.3.6.1.4.1.21367.100.1</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="Patient Management"/>
+                    </rim:Name>
+                  </rim:Classification>
+                  <rim:Classification classificationScheme="urn:uuid:f4f85eac-e6cb-4883-b524-f2705394840f"
+                                      classifiedObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                      id="urn:uuid:8fe086d2-dc6c-4e68-beee-dbfcd53ffe5d"
+                                      nodeRepresentation="R"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification">
+                    <rim:Slot name="codingScheme">
+                        <rim:ValueList>
+                            <rim:Value>2.16.840.1.113883.5.25</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="Restricted"/>
+                    </rim:Name>
+                  </rim:Classification>
+                  <rim:Classification classificationScheme="urn:uuid:a09d5840-386c-46f2-b5ad-9c3699a4309d"
+                                      classifiedObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                      id="urn:uuid:889dff26-0e1a-4b77-8a10-d3354ff3d632"
+                                      nodeRepresentation="urn:ihe:lab:xd-lab:2008"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification">
+                    <rim:Slot name="codingScheme">
+                        <rim:ValueList>
+                            <rim:Value>1.3.6.1.4.1.19376.1.2.3</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="urn:ihe:lab:xd-lab:2008"/>
+                    </rim:Name>
+                  </rim:Classification>
+                  <rim:Classification classificationScheme="urn:uuid:f33fb8ac-18af-42cc-ae0e-ed0b0bdb91e1"
+                                      classifiedObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                      id="urn:uuid:cb48d75f-3646-452a-977b-8a964e01827d"
+                                      nodeRepresentation="GYN"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification">
+                    <rim:Slot name="codingScheme">
+                        <rim:ValueList>
+                            <rim:Value>2.16.840.1.113883.5.11</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="Gynecology clinic"/>
+                    </rim:Name>
+                  </rim:Classification>
+                  <rim:Classification classificationScheme="urn:uuid:cccf5598-8b07-4b77-a05e-ae952c785ead"
+                                      classifiedObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                      id="urn:uuid:1f066918-060d-4754-87e1-23d77a45b3e2"
+                                      nodeRepresentation="Psychiatry"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification">
+                    <rim:Slot name="codingScheme">
+                        <rim:ValueList>
+                            <rim:Value>Connect-a-thon practiceSettingCodes</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="Psychiatry"/>
+                    </rim:Name>
+                  </rim:Classification>
+                  <rim:Classification classificationScheme="urn:uuid:f0306f51-975f-434e-a61c-c59651d33983"
+                                      classifiedObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                      id="urn:uuid:569d2f3d-ead3-42a5-bfed-780c855ac9bf"
+                                      nodeRepresentation="TRS TYPECODE"
+                                      objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:Classification">
+                    <rim:Slot name="codingScheme">
+                        <rim:ValueList>
+                            <rim:Value>1.3.6.1.4.1.21367.100.1</rim:Value>
+                        </rim:ValueList>
+                    </rim:Slot>
+                    <rim:Name>
+                        <rim:LocalizedString value="TRS Type Code"/>
+                    </rim:Name>
+                  </rim:Classification>
+                  <rim:ExternalIdentifier id="urn:uuid:d25b48b7-4795-4507-94fc-6acf7c7f3ce3"
+                                          identificationScheme="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab"
+                                          objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"
+                                          registryObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                          value="1.3.6.1.4.1.12559.11.1.2.2.1.1.3.36757">
+                    <rim:Name>
+                        <rim:LocalizedString value="XDSDocumentEntry.uniqueId"/>
+                    </rim:Name>
+                  </rim:ExternalIdentifier>
+                  <rim:ExternalIdentifier id="4371d182-83eb-4ae6-a805-c2e9d6cb2e28"
+                                          identificationScheme="urn:uuid:58a6f841-87b3-4a3e-92fd-a8ffeff98427"
+                                          objectType="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"
+                                          registryObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49"
+                                          value="9be1413171a8492^^^&amp;1.3.6.1.4.1.21367.2005.13.20.1000&amp;ISO">
+                    <rim:Name>
+                        <rim:LocalizedString value="XDSDocumentEntry.patientId"/>
+                    </rim:Name>
+                  </rim:ExternalIdentifier>
+               </rim:ExtrinsicObject>
+               <rim:Association associationType="urn:oasis:names:tc:ebxml-regrep:AssociationType:HasMember"
+                                id="95bd6f0c-f2b7-43c1-9706-98a3a28c3b7b"
+                                sourceObject="urn:uuid:a20ff1a4-3820-4832-9582-3bde4a74658c"
+                                targetObject="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49">
+                  <rim:Slot name="SubmissionSetStatus">
+                    <rim:ValueList>
+                        <rim:Value>Original</rim:Value>
+                    </rim:ValueList>
+                  </rim:Slot>
+               </rim:Association>
+            </rim:RegistryObjectList>
+         </lcm:SubmitObjectsRequest>
+         <xdsb:Document id="urn:uuid:18d13225-ba9d-47db-bb2b-53fba3a42a49">
+            <xop:Include href="cid:1.urn:uuid:18D13225BA9D47DBBB2B53FBA3A42A49"/>
+         </xdsb:Document>
+      </xdsb:ProvideAndRegisterDocumentSetRequest>
+   </s:Body>
+</s:Envelope>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/soap-attach.txt
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/IHE/soap-attach.txt
@@ -1,0 +1,2 @@
+a blank file with a name in it
+test

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/cms.xsd
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/cms.xsd
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- $Header: /cvsroot/ebxmlrr/ebxmlrr-spec/misc/3.0/schema/cms.xsd,v 1.3 2004/12/09 23:15:16 farrukh_najmi Exp $ -->
+<schema targetNamespace="urn:oasis:names:tc:ebxml-regrep:xsd:cms:3.0" 
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" 
+  xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" 
+  xmlns:tns="urn:oasis:names:tc:ebxml-regrep:xsd:cms:3.0"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified"
+  >
+  
+  <!-- Import the rim.xsd file with XML schema mappaing from RIM -->
+  <import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" schemaLocation="rim.xsd"/>
+  <import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" schemaLocation="rs.xsd"/>
+  <complexType name="ContentManagementServiceRequestType">
+    <annotation>
+      <documentation xml:lang="en">Base type for all Content Management Service requests.</documentation>
+    </annotation>
+    <complexContent>
+      <extension base="rs:RegistryRequestType">
+        <sequence>
+          <element name="OriginalContent" type="rim:RegistryObjectListType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="InvocationControlFile" type="rim:ExtrinsicObjectType"/>
+          <!-- The Invocation Control File (optional). -->
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="ContentManagementServiceResponseType">
+    <annotation>
+      <documentation xml:lang="en">Base type for all Content Management Service responses</documentation>
+    </annotation>
+    <complexContent>
+      <extension base="rs:RegistryResponseType">
+        <sequence/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ValidateContentRequest">
+    <annotation>
+      <documentation xml:lang="en">Request to validate specified metadata and content.</documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="tns:ContentManagementServiceRequestType">
+          <sequence/>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="ValidateContentResponse">
+    <annotation>
+      <documentation xml:lang="en">Response to request to validate specified metadata and content.</documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="tns:ContentManagementServiceResponseType">
+          <sequence/>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="CatalogContentRequest">
+    <annotation>
+      <documentation xml:lang="en">Request to catalog specified metadata and content.</documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="tns:ContentManagementServiceRequestType">
+          <sequence/>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="CatalogContentResponse">
+    <annotation>
+      <documentation xml:lang="en">Response to request to catalog specified metadata and content.</documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="tns:ContentManagementServiceResponseType">
+          <sequence>
+            <element name="CatalogedContent" type="rim:RegistryObjectListType"/>
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+</schema>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/lcm.xsd
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/lcm.xsd
@@ -1,0 +1,145 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!-- $Header: /cvsroot/ebxmlrr/ebxmlrr-spec/misc/3.0/schema/lcm.xsd,v 1.5 2005/01/31 22:28:18 farrukh_najmi Exp $ -->
+<schema targetNamespace="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0" 
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" 
+  xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" 
+  xmlns:tns="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:3.0"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified"
+  >
+  
+  <annotation>
+    <documentation xml:lang="en">The schema for OASIS ebXML Registry Services</documentation>
+  </annotation>
+  <!-- Import the rim.xsd file with XML schema mappaing from RIM -->
+  <import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" schemaLocation="rim.xsd"/>
+  <!-- Import the rs.xsd file with XML schema for base rs related schema -->
+  <import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" schemaLocation="rs.xsd"/>
+  <element name="SubmitObjectsRequest">
+    <annotation>
+      <documentation xml:lang="en">The SubmitObjectsRequest allows one to submit a list of RegistryObject elements. Each RegistryEntry element provides metadata for a single submitted object.  Note that the repository item being submitted is in a separate document that is not in this DTD. The ebXML Messaging Services Specfication defines packaging, for submission, of the metadata of a repository item with the repository item itself. The value of the id attribute of the ExtrinsicObject element must be the same as the xlink:href attribute within the Reference element within the Manifest element of the MessageHeader.</documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element ref="rim:RegistryObjectList"/>
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="UpdateObjectsRequest">
+    <annotation>
+      <documentation xml:lang="en">The UpdateObjectsRequest allows one to update a list of RegistryObject elements. Each RegistryEntry element provides metadata for a single submitted object.  Note that the repository item being submitted is in a separate document that is not in this DTD. The ebXML Messaging Services Specfication defines packaging, for submission, of the metadata of a repository item with the repository item itself. The value of the id attribute of the ExtrinsicObject element must be the same as the xlink:href attribute within the Reference element within the Manifest element of the MessageHeader.</documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element ref="rim:RegistryObjectList"/>
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="ApproveObjectsRequest">
+    <annotation>
+      <documentation xml:lang="en">
+        The ObjectRefList and AdhocQuery identify the list of
+        objects being approved.
+      </documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element ref="rim:AdhocQuery" minOccurs="0" maxOccurs="1" />          
+            <element ref="rim:ObjectRefList" minOccurs="0" maxOccurs="1" />
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="DeprecateObjectsRequest">
+    <annotation>
+      <documentation xml:lang="en">
+        The ObjectRefList and AdhocQuery identify the list of
+        objects being deprecated.
+      </documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element ref="rim:AdhocQuery" minOccurs="0" maxOccurs="1" />          
+            <element ref="rim:ObjectRefList" minOccurs="0" maxOccurs="1" />
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="UndeprecateObjectsRequest">
+    <annotation>
+      <documentation xml:lang="en">
+        The ObjectRefList is the list of
+        refs to the registry entrys being un-deprecated.
+      </documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element ref="rim:AdhocQuery" minOccurs="0" maxOccurs="1" />          
+            <element ref="rim:ObjectRefList" minOccurs="0" maxOccurs="1" />
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="RemoveObjectsRequest">
+    <annotation>
+      <documentation xml:lang="en">
+        The ObjectRefList is the list of
+        refs to the registry entrys being removed
+      </documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element ref="rim:AdhocQuery" minOccurs="0" maxOccurs="1" />          
+            <element ref="rim:ObjectRefList" minOccurs="0" maxOccurs="1" />
+          </sequence>
+          <attribute name="deletionScope" default="urn:oasis:names:tc:ebxml-regrep:DeletionScopeType:DeleteAll" type="rim:referenceURI" use="optional"/>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="RelocateObjectsRequest">
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element maxOccurs="1" minOccurs="1" ref="rim:AdhocQuery" />
+            <element maxOccurs="1" minOccurs="1" name="SourceRegistry" type="rim:ObjectRefType"/>
+            <element maxOccurs="1" minOccurs="1" name="DestinationRegistry" type="rim:ObjectRefType"/>
+            <element maxOccurs="1" minOccurs="1" name="OwnerAtSource" type="rim:ObjectRefType"/>
+            <element maxOccurs="1" minOccurs="1" name="OwnerAtDestination" type="rim:ObjectRefType"/>
+          </sequence>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="AcceptObjectsRequest">
+    <!-- The ObjectRefList must only contain local ObjectRefs such that they do not specify home attribute -->
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <attribute name="correlationId" type="anyURI" use="required"/>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+</schema>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/query.xsd
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/query.xsd
@@ -1,0 +1,446 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!-- $Header: /cvsroot/ebxmlrr/ebxmlrr-spec/misc/3.0/schema/query.xsd,v 1.13 2005/03/29 08:52:10 farrukh_najmi Exp $ -->
+<schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" xmlns:tns="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0">
+  <!-- Import the rim.xsd file with XML schema mappaing from RIM -->
+  <import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" schemaLocation="rim.xsd"/>
+  <import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" schemaLocation="rs.xsd"/>
+  <complexType name="ResponseOptionType">
+    <attribute default="RegistryObject" name="returnType">
+      <simpleType>
+        <restriction base="NCName">
+          <enumeration value="ObjectRef"/>
+          <enumeration value="RegistryObject"/>
+          <enumeration value="LeafClass"/>
+          <enumeration value="LeafClassWithRepositoryItem"/>
+        </restriction>
+      </simpleType>
+    </attribute>
+    <attribute default="false" name="returnComposedObjects" type="boolean"/>
+  </complexType>
+  <element name="ResponseOption" type="tns:ResponseOptionType"/>
+  <element name="AdhocQueryRequest">
+    <annotation>
+      <documentation xml:lang="en">An Ad hoc query request specifies an ad hoc query.</documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryRequestType">
+          <sequence>
+            <element maxOccurs="1" minOccurs="1" ref="tns:ResponseOption"/>
+            <element ref="rim:AdhocQuery"/>
+          </sequence>
+          <attribute default="false" name="federated" type="boolean" use="optional"/>
+          <attribute name="federation" type="anyURI" use="optional"/>
+          <attribute default="0" name="startIndex" type="integer"/>
+          <attribute default="-1" name="maxResults" type="integer"/>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <element name="AdhocQueryResponse">
+    <annotation>
+      <documentation xml:lang="en">
+        The response includes a RegistryObjectList which has zero or more
+        RegistryObjects that match the query specified in AdhocQueryRequest.
+      </documentation>
+    </annotation>
+    <complexType>
+      <complexContent>
+        <extension base="rs:RegistryResponseType">
+          <sequence>
+            <element ref="rim:RegistryObjectList"/>
+          </sequence>
+          <attribute default="0" name="startIndex" type="integer"/>
+          <attribute name="totalResultCount" type="integer" use="optional"/>
+        </extension>
+      </complexContent>
+    </complexType>
+  </element>
+  <complexType name="FilterQueryType" abstract="true">
+    <sequence>
+      <element maxOccurs="1" minOccurs="0" name="PrimaryFilter" type="tns:FilterType"/>
+    </sequence>
+  </complexType>
+  
+  <complexType name="BranchType" abstract="true">
+    <complexContent>
+      <extension base="tns:FilterQueryType">
+      </extension>
+    </complexContent>
+  </complexType>
+  <complexType name="InternationalStringBranchType">
+    <complexContent>
+      <extension base="tns:BranchType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="LocalizedStringFilter" type="tns:FilterType" />
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  
+  <complexType name="SlotBranchType">
+    <complexContent>
+      <extension base="tns:BranchType">
+        <sequence/>
+      </extension>
+    </complexContent>
+  </complexType>
+  
+  <complexType name="RegistryObjectQueryType">
+    <complexContent>
+      <extension base="tns:FilterQueryType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="SlotBranch" type="tns:SlotBranchType"/>
+          <element maxOccurs="1" minOccurs="0" name="NameBranch" type="tns:InternationalStringBranchType"/>
+          <element maxOccurs="1" minOccurs="0" name="DescriptionBranch" type="tns:InternationalStringBranchType"/>
+          <element maxOccurs="1" minOccurs="0" name="VersionInfoFilter" type="tns:FilterType" />          
+          <element maxOccurs="unbounded" minOccurs="0" ref="tns:ClassificationQuery"/>
+          <element maxOccurs="unbounded" minOccurs="0" ref="tns:ExternalIdentifierQuery"/>
+          <element maxOccurs="1" minOccurs="0" name="ObjectTypeQuery" type="tns:ClassificationNodeQueryType"/>          
+          <element maxOccurs="1" minOccurs="0" name="StatusQuery" type="tns:ClassificationNodeQueryType"/>          
+          <element maxOccurs="unbounded" minOccurs="0" name="SourceAssociationQuery" type="tns:AssociationQueryType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="TargetAssociationQuery" type="tns:AssociationQueryType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="RegistryObjectQuery" type="tns:RegistryObjectQueryType"/>
+
+  <complexType name="AssociationQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="AssociationTypeQuery" type="tns:ClassificationNodeQueryType"/>          
+          <element maxOccurs="1" minOccurs="0" name="SourceObjectQuery" type="tns:RegistryObjectQueryType"/>
+          <element maxOccurs="1" minOccurs="0" name="TargetObjectQuery" type="tns:RegistryObjectQueryType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="AssociationQuery" type="tns:AssociationQueryType"/>
+  
+  <complexType name="AuditableEventQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="AffectedObjectQuery" type="tns:RegistryObjectQueryType" />          
+          <element maxOccurs="1" minOccurs="0" name="EventTypeQuery" type="tns:ClassificationNodeQueryType" />
+          <element maxOccurs="1" minOccurs="0" name="UserQuery" type="tns:UserQueryType" />
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>  
+  <element name="AuditableEventQuery" type="tns:AuditableEventQueryType"/>
+    
+  <complexType name="ClassificationQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" ref="tns:ClassificationSchemeQuery"/>
+          <element maxOccurs="1" minOccurs="0" name="ClassifiedObjectQuery" type="tns:RegistryObjectQueryType"/>
+          <element maxOccurs="1" minOccurs="0" ref="tns:ClassificationNodeQuery"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ClassificationQuery" type="tns:ClassificationQueryType"/>
+  
+  <complexType name="ClassificationNodeQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="ParentQuery" type="tns:RegistryObjectQueryType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="ChildrenQuery" type="tns:ClassificationNodeQueryType"/>
+       </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ClassificationNodeQuery" type="tns:ClassificationNodeQueryType" />
+    
+  <complexType name="ClassificationSchemeQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="ChildrenQuery" type="tns:ClassificationNodeQueryType"/>
+          <element maxOccurs="1" minOccurs="0" name="NodeTypeQuery" type="tns:ClassificationNodeQueryType"/>
+       </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ClassificationSchemeQuery" type="tns:ClassificationSchemeQueryType"/>
+
+  <complexType name="ExternalIdentifierQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" ref="tns:RegistryObjectQuery" />
+          <element maxOccurs="1" minOccurs="0" name="IdentificationSchemeQuery" type="tns:ClassificationSchemeQueryType"/>
+       </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ExternalIdentifierQuery" type="tns:ExternalIdentifierQueryType"/>
+  
+  <complexType name="ExternalLinkQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ExternalLinkQuery" type="tns:ExternalLinkQueryType"/>
+  
+  <complexType name="ExtrinsicObjectQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="ContentVersionInfoFilter" type="tns:FilterType"/>          
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ExtrinsicObjectQuery" type="tns:ExtrinsicObjectQueryType"/>
+  
+  <complexType name="OrganizationQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="AddressFilter" type="tns:FilterType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="TelephoneNumberFilter" type="tns:FilterType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="EmailAddressFilter" type="tns:FilterType"/>
+          <element maxOccurs="1" minOccurs="0" name="ParentQuery" type="tns:OrganizationQueryType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="ChildOrganizationQuery" type="tns:OrganizationQueryType"/>
+          <element maxOccurs="1" minOccurs="0" name="PrimaryContactQuery" type="tns:PersonQueryType"/>          
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="OrganizationQuery" type="tns:OrganizationQueryType"/>
+    
+  <complexType name="RegistryPackageQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="RegistryPackageQuery" type="tns:RegistryPackageQueryType"/>
+  
+  <complexType name="ServiceQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" ref="tns:ServiceBindingQuery"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ServiceQuery" type="tns:ServiceQueryType"/>
+  
+  <complexType name="ServiceBindingQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" ref="tns:ServiceQuery"/>
+          <element maxOccurs="unbounded" minOccurs="0" ref="tns:SpecificationLinkQuery"/>
+          <element maxOccurs="1" minOccurs="0" name="TargetBindingQuery" type="tns:ServiceBindingQueryType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="ServiceBindingQuery" type="tns:ServiceBindingQueryType"/> 
+   
+  <complexType name="SpecificationLinkQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="UsageDescriptionBranch" type="tns:InternationalStringBranchType"/>
+          <element maxOccurs="1" minOccurs="0" ref="tns:ServiceBindingQuery"/>
+          <element maxOccurs="1" minOccurs="0" name="SpecificationObjectQuery" type="tns:RegistryObjectQueryType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="SpecificationLinkQuery" type="tns:SpecificationLinkQueryType"/>  
+
+  <complexType name="PersonQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="unbounded" minOccurs="0" name="AddressFilter" type="tns:FilterType"/>
+          <element maxOccurs="1" minOccurs="0" name="PersonNameFilter" type="tns:FilterType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="TelephoneNumberFilter" type="tns:FilterType"/>
+          <element maxOccurs="unbounded" minOccurs="0" name="EmailAddressFilter" type="tns:FilterType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="PersonQuery" type="tns:PersonQueryType"/>  
+  
+  <complexType name="UserQueryType">
+    <complexContent>
+      <extension base="tns:PersonQueryType">
+        <sequence/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="UserQuery" type="tns:UserQueryType"/>  
+
+  <complexType name="RegistryQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="OperatorQuery" type="tns:OrganizationQueryType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="RegistryQuery" type="tns:RegistryQueryType"/>  
+         
+  <complexType name="FederationQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="FederationQuery" type="tns:FederationQueryType"/>
+
+  <complexType name="AdhocQueryQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="QueryExpressionBranch" type="tns:QueryExpressionBranchType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="AdhocQueryQuery" type="tns:AdhocQueryQueryType"/>
+
+  <complexType name="QueryExpressionBranchType">
+    <complexContent>
+      <extension base="tns:BranchType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="QueryLanguageQuery" type="tns:ClassificationNodeQueryType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+      
+  <complexType name="NotificationQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" ref="tns:RegistryObjectQuery"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="NotificationQuery" type="tns:NotificationQueryType"/>
+    
+  <complexType name="SubscriptionQueryType">
+    <complexContent>
+      <extension base="tns:RegistryObjectQueryType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="0" name="SelectorQuery" type="tns:AdhocQueryQueryType"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="SubscriptionQuery" type="tns:SubscriptionQueryType"/>
+    
+  <!-- The Filter type hierarchy -->
+  <complexType name="FilterType">
+    <attribute default="false" name="negate" type="boolean"/>
+  </complexType>
+  <element abstract="true" name="Filter" type="tns:FilterType"/>  
+
+  <complexType name="CompoundFilterType">
+    <complexContent>
+      <extension base="tns:FilterType">
+        <sequence>
+          <element maxOccurs="1" minOccurs="1" name="LeftFilter" type="tns:FilterType"/>
+          <element maxOccurs="1" minOccurs="1" name="RightFilter" type="tns:FilterType"/>
+        </sequence>
+        <attribute name="logicalOperator" use="required">
+          <simpleType>
+            <restriction base="NCName">
+              <enumeration value="AND"/>
+              <enumeration value="OR"/>
+            </restriction>
+          </simpleType>
+        </attribute>
+      </extension>
+    </complexContent>
+  </complexType>  
+  <element name="CompoundFilter"  type="tns:CompoundFilterType"/>
+    
+    
+  <complexType name="SimpleFilterType" abstract="true">
+    <complexContent>
+      <extension base="tns:FilterType">
+        <attribute name="domainAttribute" type="string" use="required"/>
+        <attribute name="comparator" use="required">
+          <simpleType>
+            <restriction base="NCName">
+              <enumeration value="LE"/>
+              <enumeration value="LT"/>
+              <enumeration value="GE"/>
+              <enumeration value="GT"/>
+              <enumeration value="EQ"/>
+              <enumeration value="NE"/>
+              <enumeration value="Like"/>
+              <enumeration value="NotLike"/>
+            </restriction>
+          </simpleType>
+        </attribute>
+      </extension>
+    </complexContent>
+  </complexType>
+
+  <complexType name="BooleanFilterType">
+    <complexContent>
+      <extension base="tns:SimpleFilterType">
+        <attribute name="value" type="boolean" use="required"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="BooleanFilter"  type="tns:BooleanFilterType"/>
+
+  
+  <complexType name="IntegerFilterType">
+    <complexContent>
+      <extension base="tns:SimpleFilterType">
+        <attribute name="value" type="integer" use="required"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="IntegerFilter"  type="tns:IntegerFilterType"/>
+  
+  <complexType name="FloatFilterType">
+    <complexContent>
+      <extension base="tns:SimpleFilterType">
+        <attribute name="value" type="float" use="required"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="FloatFilter"  type="tns:FloatFilterType"/>
+  
+  <complexType name="DateTimeFilterType">
+    <complexContent>
+      <extension base="tns:SimpleFilterType">
+        <attribute name="value" type="dateTime" use="required"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="DateTimeFilter"  type="tns:DateTimeFilterType"/>
+  
+  <complexType name="StringFilterType">
+    <complexContent>
+      <extension base="tns:SimpleFilterType">
+        <attribute name="value" type="string" use="required"/>
+      </extension>
+    </complexContent>
+  </complexType>
+  <element name="StringFilter"  type="tns:StringFilterType"/>
+  
+</schema>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/rim.xsd
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/rim.xsd
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- $Header: /cvsroot/ebxmlrr/ebxmlrr-spec/misc/3.0/schema/rim.xsd,v 1.20 2005/02/03 19:28:15 farrukh_najmi Exp $ -->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:tns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" xmlns:xml="http://www.w3.org/XML/1998/namespace" targetNamespace="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<annotation>
+		<documentation xml:lang="en">The schema for OASIS ebXML Registry Information Model</documentation>
+	</annotation>
+	<import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<!-- Begin information model mapping from ebRIM. -->
+	<!-- Define Data Types -->
+	<simpleType name="referenceURI">
+		<annotation>
+			<documentation xml:lang="en">
+        referenceURI is used by reference attributes within RIM.
+        Each attribute of type referenceURI references a RegistryObject with
+        specified URI as id.
+      </documentation>
+		</annotation>
+		<restriction base="anyURI"/>
+	</simpleType>
+	<simpleType name="String4">
+		<restriction base="string">
+			<maxLength value="4"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="String8">
+		<restriction base="string">
+			<maxLength value="8"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="String16">
+		<restriction base="string">
+			<maxLength value="16"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="String32">
+		<restriction base="string">
+			<maxLength value="32"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ShortName">
+		<restriction base="string">
+			<maxLength value="64"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="LongName">
+		<restriction base="string">
+			<maxLength value="256"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="FreeFormText">
+		<restriction base="string">
+			<maxLength value="1024"/>
+		</restriction>
+	</simpleType>
+	<complexType name="InternationalStringType">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element ref="tns:LocalizedString"/>
+		</sequence>
+	</complexType>
+	<element name="InternationalString" type="tns:InternationalStringType"/>
+	<element name="Name" type="tns:InternationalStringType"/>
+	<element name="Description" type="tns:InternationalStringType"/>
+	<complexType name="LocalizedStringType">
+		<attribute ref="xml:lang" default="en-US"/>
+		<attribute name="charset" default="UTF-8"/>
+		<attribute name="value" type="tns:FreeFormText" use="required"/>
+	</complexType>
+	<element name="LocalizedString" type="tns:LocalizedStringType"/>
+	<complexType name="SlotType1">
+		<sequence>
+			<element ref="tns:ValueList" minOccurs="1" maxOccurs="1"/>
+		</sequence>
+		<attribute name="name" type="tns:LongName" use="required"/>
+		<attribute name="slotType" type="tns:referenceURI" use="optional"/>
+		<!--slotType value MUST reference a ClassificationNode in the canonical DataType scheme-->
+	</complexType>
+	<element name="Slot" type="tns:SlotType1"/>
+	<complexType name="ValueListType">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element ref="tns:Value"/>
+		</sequence>
+	</complexType>
+	<element name="ValueList" type="tns:ValueListType"/>
+	<element name="Value" type="tns:LongName"/>
+	<complexType name="SlotListType">
+		<sequence>
+			<element ref="tns:Slot" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<element name="SlotList" type="tns:SlotListType"/>
+	<complexType name="IdentifiableType">
+		<annotation>
+			<documentation xml:lang="en">
+        Common base type for all types that have unique identity.     
+        If id is provided and is not in proper URN syntax then it is used for
+        linkage within document and is ignored by the registry. In this case the
+        registry generates a UUID URN for id attribute.
+        id must not be null when object is retrieved from the registry.
+      </documentation>
+		</annotation>
+		<sequence>
+			<element ref="tns:Slot" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="id" type="anyURI" use="required"/>
+		<attribute name="home" type="anyURI" use="optional"/>
+		<!-- home attribute is required only for remote ObjectRef -->
+	</complexType>
+	<element name="Identifiable" type="tns:IdentifiableType"/>
+	<complexType name="ObjectRefType">
+		<annotation>
+			<documentation xml:lang="en">
+        Use to reference an Object by its id.
+        Specifies the id attribute of the object as its id attribute.
+        id attribute in ObjectAttributes is exactly the same syntax and semantics as
+        id attribute in RegistryObject.
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:IdentifiableType">
+				<attribute name="createReplica" type="boolean" default="false"/>
+			</extension>
+			<!-- When true and is a remote ObjectRef then the registry must create a replica for this ObjectRef -->
+		</complexContent>
+	</complexType>
+	<complexType name="ObjectRefListType">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element ref="tns:ObjectRef"/>
+		</sequence>
+	</complexType>
+	<element name="ObjectRefList" type="tns:ObjectRefListType"/>
+	<element name="ObjectRef" type="tns:ObjectRefType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="RegistryObjectType">
+		<complexContent>
+			<extension base="tns:IdentifiableType">
+				<sequence minOccurs="0" maxOccurs="1">
+					<element ref="tns:Name" minOccurs="0" maxOccurs="1"/>
+					<element ref="tns:Description" minOccurs="0" maxOccurs="1"/>
+					<element name="VersionInfo" type="tns:VersionInfoType" minOccurs="0" maxOccurs="1"/>
+					<element ref="tns:Classification" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="tns:ExternalIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute name="lid" type="anyURI" use="optional"/>
+				<attribute name="objectType" type="tns:referenceURI" use="optional"/>
+				<attribute name="status" type="tns:referenceURI" use="optional"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="RegistryObject" type="tns:RegistryObjectType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="RegistryObjectListType">
+		<sequence>
+			<element ref="tns:Identifiable" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<element name="RegistryObjectList" type="tns:RegistryObjectListType"/>
+	<complexType name="AssociationType1">
+		<annotation>
+			<documentation xml:lang="en">
+        Association is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+        An Association specifies references to two previously submitted
+        registry entrys.
+        The sourceObject is id of the sourceObject in association
+        The targetObject is id of the targetObject in association
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<attribute name="associationType" type="tns:referenceURI" use="required"/>
+				<attribute name="sourceObject" type="tns:referenceURI" use="required"/>
+				<attribute name="targetObject" type="tns:referenceURI" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Association" type="tns:AssociationType1" substitutionGroup="tns:Identifiable"/>
+	<complexType name="AuditableEventType">
+		<annotation>
+			<documentation xml:lang="en">An Event that forms an audit trail in ebXML Registry.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<!-- List of all objects that have been effected by this event -->
+					<element name="affectedObjects" type="tns:ObjectRefListType" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+				<attribute name="eventType" type="tns:referenceURI" use="required"/>
+				<attribute name="timestamp" type="dateTime" use="required"/>
+				<attribute name="user" type="tns:referenceURI" use="required"/>
+				<attribute name="requestId" type="tns:referenceURI" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="AuditableEvent" type="tns:AuditableEventType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ClassificationType">
+		<annotation>
+			<documentation xml:lang="en">
+        Classification is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+        A Classification specifies references to two registry entrys.
+        The classifiedObject is id of the Object being classified.
+        The classificationNode is id of the ClassificationNode classying the object
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<attribute name="classificationScheme" type="tns:referenceURI" use="optional"/>
+				<attribute name="classifiedObject" type="tns:referenceURI" use="required"/>
+				<attribute name="classificationNode" type="tns:referenceURI" use="optional"/>
+				<attribute name="nodeRepresentation" type="tns:LongName" use="optional"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Classification" type="tns:ClassificationType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ClassificationNodeType">
+		<annotation>
+			<documentation xml:lang="en">
+        ClassificationNode is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+        ClassificationNode is used to submit a Classification tree to the Registry.
+        The parent attribute is the id to the parent node. code is an optional code value for a ClassificationNode
+        often defined by an external taxonomy (e.g. NAICS)
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:ClassificationNode" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute name="parent" type="tns:referenceURI" use="optional"/>
+				<attribute name="code" type="tns:LongName" use="optional"/>
+				<attribute name="path" type="string" use="optional"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="ClassificationNode" type="tns:ClassificationNodeType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ClassificationSchemeType">
+		<annotation>
+			<documentation xml:lang="en">
+        ClassificationScheme is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:ClassificationNode" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute name="isInternal" type="boolean" use="required"/>
+				<attribute name="nodeType" type="tns:referenceURI" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="ClassificationScheme" type="tns:ClassificationSchemeType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ExternalIdentifierType">
+		<annotation>
+			<documentation xml:lang="en">
+        ExternalIdentifier is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<attribute name="registryObject" type="tns:referenceURI" use="required"/>
+				<attribute name="identificationScheme" type="tns:referenceURI" use="required"/>
+				<attribute name="value" type="tns:LongName" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="ExternalIdentifier" type="tns:ExternalIdentifierType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ExternalLinkType">
+		<annotation>
+			<documentation xml:lang="en">
+        ExternalLink is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<attribute name="externalURI" type="anyURI" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="ExternalLink" type="tns:ExternalLinkType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ExtrinsicObjectType">
+		<annotation>
+			<documentation xml:lang="en">
+        ExtrinsicObject is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element name="ContentVersionInfo" type="tns:VersionInfoType" minOccurs="0" maxOccurs="1"/>
+				</sequence>
+				<attribute name="mimeType" type="tns:LongName" default="application/octet-stream"/>
+				<attribute name="isOpaque" type="boolean" default="false"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- Following element decl nneds to be lower case but using upper camel case for backward compatibility -->
+	<element name="ExtrinsicObject" type="tns:ExtrinsicObjectType" substitutionGroup="tns:Identifiable"/>
+	<element name="Address" type="tns:PostalAddressType"/>
+	<complexType name="OrganizationType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:Address" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="tns:TelephoneNumber" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="tns:EmailAddress" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute name="parent" type="tns:referenceURI"/>
+				<attribute name="primaryContact" type="tns:referenceURI" use="optional"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Organization" type="tns:OrganizationType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="PersonNameType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<attribute name="firstName" type="tns:ShortName" use="optional"/>
+		<attribute name="middleName" type="tns:ShortName" use="optional"/>
+		<attribute name="lastName" type="tns:ShortName" use="optional"/>
+	</complexType>
+	<element name="PersonName" type="tns:PersonNameType"/>
+	<complexType name="EmailAddressType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<attribute name="address" type="tns:ShortName" use="required"/>
+		<attribute name="type" type="tns:String32" use="optional"/>
+	</complexType>
+	<element name="EmailAddress" type="tns:EmailAddressType"/>
+	<complexType name="PostalAddressType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<attribute name="city" type="tns:ShortName" use="optional"/>
+		<attribute name="country" type="tns:ShortName" use="optional"/>
+		<attribute name="postalCode" type="tns:ShortName" use="optional"/>
+		<attribute name="stateOrProvince" type="tns:ShortName" use="optional"/>
+		<attribute name="street" type="tns:ShortName" use="optional"/>
+		<attribute name="streetNumber" type="tns:String32" use="optional"/>
+	</complexType>
+	<element name="PostalAddress" type="tns:PostalAddressType"/>
+	<complexType name="VersionInfoType">
+		<attribute name="versionName" type="tns:String16" use="optional" default="1.1"/>
+		<attribute name="comment" type="string" use="optional"/>
+	</complexType>
+	<complexType name="RegistryPackageType">
+		<annotation>
+			<documentation xml:lang="en">
+        RegistryPackage is the mapping of the same named interface in ebRIM.
+        It extends RegistryObject.
+        A RegistryPackage is a named collection of objects.
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:RegistryObjectList" minOccurs="0" maxOccurs="1"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="RegistryPackage" type="tns:RegistryPackageType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ServiceType">
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:ServiceBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Service" type="tns:ServiceType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ServiceBindingType">
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:SpecificationLink" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute name="service" type="tns:referenceURI" use="required"/>
+				<attribute name="accessURI" type="anyURI" use="optional"/>
+				<attribute name="targetBinding" type="tns:referenceURI" use="optional"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="ServiceBinding" type="tns:ServiceBindingType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="SpecificationLinkType">
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:UsageDescription" minOccurs="0" maxOccurs="1"/>
+					<element ref="tns:UsageParameter" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute name="serviceBinding" type="tns:referenceURI" use="required"/>
+				<attribute name="specificationObject" type="tns:referenceURI" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="SpecificationLink" type="tns:SpecificationLinkType" substitutionGroup="tns:Identifiable"/>
+	<element name="UsageDescription" type="tns:InternationalStringType"/>
+	<element name="UsageParameter" type="tns:FreeFormText"/>
+	<complexType name="TelephoneNumberType">
+		<annotation>
+			<documentation xml:lang="en">TelephoneNumber is the mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<attribute name="areaCode" type="tns:String8" use="optional"/>
+		<attribute name="countryCode" type="tns:String8" use="optional"/>
+		<attribute name="extension" type="tns:String8" use="optional"/>
+		<attribute name="number" type="tns:String16" use="optional"/>
+		<attribute name="phoneType" type="tns:String32" use="optional"/>
+	</complexType>
+	<element name="TelephoneNumber" type="tns:TelephoneNumberType"/>
+	<complexType name="TelephoneNumberListType">
+		<sequence>
+			<element ref="tns:TelephoneNumber" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="PersonType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence minOccurs="1" maxOccurs="1">
+					<element ref="tns:Address" minOccurs="0" maxOccurs="unbounded"/>
+					<!-- 
+          PersonName is optional because it is not needed in SAML Profile 
+          when an external IdentityProvider is used.
+          -->
+					<element ref="tns:PersonName" minOccurs="0" maxOccurs="1"/>
+					<element ref="tns:TelephoneNumber" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="tns:EmailAddress" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Person" type="tns:PersonType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="UserType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:PersonType"/>
+		</complexContent>
+	</complexType>
+	<element name="User" type="tns:UserType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="RegistryType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<attribute name="operator" type="tns:referenceURI" use="required"/>
+				<attribute name="specificationVersion" type="string" use="required"/>
+				<attribute name="replicationSyncLatency" type="duration" use="optional" default="P1D"/>
+				<attribute name="catalogingLatency" type="duration" use="optional" default="P1D"/>
+				<attribute name="conformanceProfile" use="optional" default="registryLite">
+					<simpleType>
+						<restriction base="NCName">
+							<enumeration value="registryFull"/>
+							<enumeration value="registryLite"/>
+						</restriction>
+					</simpleType>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Registry" type="tns:RegistryType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="FederationType">
+		<annotation>
+			<documentation xml:lang="en">Mapping of the same named interface in ebRIM.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<attribute name="replicationSyncLatency" type="duration" use="optional" default="P1D"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Federation" type="tns:FederationType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="AdhocQueryType">
+		<annotation>
+			<documentation xml:lang="en">
+      A registry query.
+      A QueryExpression child element is not required when invoking a stored query.
+      </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:QueryExpression" minOccurs="0" maxOccurs="1"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="AdhocQuery" type="tns:AdhocQueryType" substitutionGroup="tns:RegistryObject"/>
+	<complexType name="QueryExpressionType" mixed="true">
+		<sequence>
+			<!--
+      MAY be any query language syntax supported. 
+      MUST support FilterQuery. SHOULD support SQLQuery
+      -->
+			<any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="1"/>
+		</sequence>
+		<attribute name="queryLanguage" type="tns:referenceURI" use="required"/>
+	</complexType>
+	<element name="QueryExpression" type="tns:QueryExpressionType"/>
+	<complexType name="NotificationType">
+		<annotation>
+			<documentation>Notification of registry events.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<!--May contain ObjectRefs and RegistryObjects -->
+					<element ref="tns:RegistryObjectList" minOccurs="1" maxOccurs="1"/>
+				</sequence>
+				<attribute name="subscription" type="tns:referenceURI" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="Notification" type="tns:NotificationType"/>
+	<element name="Action" type="tns:ActionType"/>
+	<complexType name="SubscriptionType">
+		<annotation>
+			<documentation xml:lang="en">A Subscription for specified Events in an ebXML V3+ registry.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:RegistryObjectType">
+				<sequence>
+					<element ref="tns:Action" minOccurs="0" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute name="selector" type="tns:referenceURI" use="required"/>
+				<attribute name="startTime" type="dateTime" use="optional"/>
+				<attribute name="endTime" type="dateTime" use="optional"/>
+				<attribute name="notificationInterval" type="duration" use="optional" default="P1D"/>
+			</extension>
+			<!-- Ref to a AdhocQueryType instance -->
+		</complexContent>
+	</complexType>
+	<element name="Subscription" type="tns:SubscriptionType" substitutionGroup="tns:Identifiable"/>
+	<complexType name="ActionType" abstract="true">
+		<annotation>
+			<documentation>Abstract Base type for all types of Actions.</documentation>
+		</annotation>
+	</complexType>
+	<complexType name="NotifyActionType">
+		<annotation>
+			<documentation xml:lang="en">Abstract Base type for all types of Notify Actions</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="tns:ActionType">
+				<attribute name="notificationOption" type="tns:referenceURI" default="urn:oasis:names:tc:ebxml-regrep:NotificationOptionType:ObjectRefs"/>
+				<attribute name="endPoint" type="anyURI" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<element name="NotifyAction" type="tns:NotifyActionType" substitutionGroup="tns:Action"/>
+</schema>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/rs.xsd
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/artifacts/OASIS/ebRS/rs.xsd
@@ -1,0 +1,66 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!-- $Header: /cvsroot/ebxmlrr/ebxmlrr-spec/misc/3.0/schema/rs.xsd,v 1.9 2005/01/31 22:33:54 farrukh_najmi Exp $ -->
+<schema targetNamespace="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" 
+  xmlns="http://www.w3.org/2001/XMLSchema" 
+  xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" 
+  xmlns:tns="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified"
+  >
+  
+  <annotation>
+    <documentation xml:lang="en">The schema for OASIS ebXML Registry Services</documentation>
+  </annotation>
+  <!-- Import the rim.xsd file with XML schema mappaing from RIM -->
+  <import namespace="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0" schemaLocation="rim.xsd"/>
+  <complexType name="RegistryRequestType">
+    <annotation>
+      <documentation xml:lang="en">Base type for all ebXML Registry requests</documentation>
+    </annotation>
+    <sequence>
+      <!-- every request may be extended using Slots. -->
+      <element maxOccurs="1" minOccurs="0" name="RequestSlotList" type="rim:SlotListType"/>
+    </sequence>    
+    <attribute name="id" type="anyURI" use="optional"/>
+    <!--Comment may be used by requestor to describe the request. Used in VersionInfo.comment-->
+    <attribute name="comment" type="string" use="optional"/>
+  </complexType>
+  <element name="RegistryRequest" type="tns:RegistryRequestType"/>  
+  <element name="RegistryErrorList">
+    <annotation>
+      <documentation xml:lang="en">The RegistryErrorList is derived from the ErrorList element from the ebXML Message Service Specification</documentation>
+    </annotation>
+    <complexType>
+      <sequence>
+        <element maxOccurs="unbounded" ref="tns:RegistryError"/>
+      </sequence>
+      <attribute name="highestSeverity" type="rim:referenceURI" use="optional"/>
+    </complexType>
+  </element>
+  <element name="RegistryError">
+    <complexType>
+      <simpleContent>
+        <extension base="string">
+          <attribute name="codeContext" type="string" use="required"/>
+          <attribute name="errorCode" type="string" use="required"/>
+          <attribute default="urn:oasis:names:tc:ebxml-regrep:ErrorSeverityType:Error" name="severity" type="rim:referenceURI" />
+          <attribute name="location" type="string" use="optional"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+  </element>
+  <complexType name="RegistryResponseType">
+    <annotation>
+      <documentation xml:lang="en">Base type for all ebXML Registry responses</documentation>
+    </annotation>
+    <sequence>
+      <!-- every response may be extended using Slots. -->
+      <element maxOccurs="1" minOccurs="0" name="ResponseSlotList" type="rim:SlotListType"/>
+      <element minOccurs="0" ref="tns:RegistryErrorList"/>
+    </sequence>
+    <attribute name="status" type="rim:referenceURI" use="required"/>
+    <!-- id is the request if for the request for which this is a response -->
+    <attribute name="requestId" type="anyURI" use="optional"/>
+  </complexType>
+  <element name="RegistryResponse" type="tns:RegistryResponseType"/>
+</schema>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentRepository-IHE-ProvideAndRegister.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentRepository-IHE-ProvideAndRegister.xml
@@ -33,10 +33,8 @@
             <value name="Content-Type" type="string">multipart/related; type="application/xop+xml";</value>
         </var>
 
-        <var name="soap_attachments" type="map">
-            <value name="cid:1.urn:uuid:18D13225BA9D47DBBB2B53FBA3A42A49" type="binary" source="$DocRepo_Attachment" />
-        </var>
-
+        <var name="soap_attachments" type="map" />
+        
         <var name="soap_address" type="string" />
         
         <!-- Participant Identifier of Sender Access Point (System Under Test). Must be retrieved
@@ -47,6 +45,8 @@
 
     </variables>
     <steps>
+        <assign to="$soap_attachments{attachment1}" source="$DocRepo_Attachment" />
+
         <btxn from="DocumentSource" to="DocumentRepository" txnId="t1" handler="SoapMessaging"/>
         <send id="soap_input" desc="Provide and Register Set-b (one Document)" from="DocumentSource" to="DocumentRepository" txnId="t1">
             <input name="soap_message" source="$DocRepo_Template_out" />

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentRepository-IHE-ProvideAndRegister.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentRepository-IHE-ProvideAndRegister.xml
@@ -29,10 +29,6 @@
         <var name="soap_output2" type="map"/>
         <var name="soap_input" type="map"/>
 
-        <var name="soap_header" type="map">
-            <value name="Content-Type" type="string">multipart/related; type="application/xop+xml";</value>
-        </var>
-
         <var name="soap_attachments" type="map" />
         
         <var name="soap_address" type="string" />
@@ -50,7 +46,6 @@
         <btxn from="DocumentSource" to="DocumentRepository" txnId="t1" handler="SoapMessaging"/>
         <send id="soap_input" desc="Provide and Register Set-b (one Document)" from="DocumentSource" to="DocumentRepository" txnId="t1">
             <input name="soap_message" source="$DocRepo_Template_out" />
-            <input name="http_headers" source="$soap_header" />
             <input name="soap_attachments" source="$soap_attachments" />
             <config name="soap.version">1.2</config>
         </send>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentRepository-IHE-ProvideAndRegister.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentRepository-IHE-ProvideAndRegister.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testcase id="DocumentRepository-IHE-ProvideAndRegister" xmlns="http://www.gitb.com/tdl/v1/" xmlns:gitb="http://www.gitb.com/core/v1/">
+    <metadata>
+        <gitb:name>DocumentRepository-IHE-ProvideAndRegister</gitb:name>
+        <gitb:type>CONFORMANCE</gitb:type>
+        <gitb:version>0.1</gitb:version>
+        <gitb:description>This test scenario tests the Document Repository. IHE XDS.b ITI-41 Provide and Register Set-b</gitb:description>
+    </metadata>
+    <namespaces>
+    </namespaces>
+    <imports>
+        <artifact type="schema" encoding="UTF-8" name="XDSb_DocumentRepository">IHE_XDSb_SharingOfDocument/artifacts/IHE/XDS/XDS.b_DocumentRepository.xsd</artifact>
+        <artifact type="object" encoding="UTF-8" name="DocRepo_Template_out">IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-xdsb-request-ITI41.xml</artifact>
+        <artifact type="object" encoding="UTF-8" name="DocRepo_Template">IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-docrepo-template.xml</artifact>
+        <artifact type="binary" encoding="UTF-8" name="DocRepo_Attachment">IHE_XDSb_SharingOfDocument/artifacts/IHE/soap-attach.txt</artifact>
+    </imports>
+    <actors>
+        <gitb:actor id="DocumentSource" name="DocumentSource" role="SIMULATED" >
+            <gitb:endpoint name="soap">
+                <gitb:config name="patient.id">9be1413171a8492^^^&amp;1.3.6.1.4.1.21367.2005.13.20.1000&amp;ISO</gitb:config>
+            </gitb:endpoint>
+        </gitb:actor>
+        <gitb:actor id="DocumentRepository" name="DocumentRepository" role="SUT" />
+        <gitb:actor id="DocumentRegistry" name="DocumentRegistry" role="SIMULATED" />
+        <gitb:actor id="DocumentConsumer" name="DocumentConsumer" role="SIMULATED" />
+    </actors>
+    <variables>
+        <var name="soap_output1" type="map"/>
+        <var name="soap_output2" type="map"/>
+        <var name="soap_input" type="map"/>
+
+        <var name="soap_header" type="map">
+            <value name="Content-Type" type="string">multipart/related; type="application/xop+xml";</value>
+        </var>
+
+        <var name="soap_attachments" type="map">
+            <value name="cid:1.urn:uuid:18D13225BA9D47DBBB2B53FBA3A42A49" type="binary" source="$DocRepo_Attachment" />
+        </var>
+
+        <var name="soap_address" type="string" />
+        
+        <!-- Participant Identifier of Sender Access Point (System Under Test). Must be retrieved
+             from SUT representative -->
+        <var name="source_patient_id" type="string" />
+        <!-- Participant Identifier of Receiver Access Point (Simulated) -->
+        <var name="repository_patient_id" type="string" />
+
+    </variables>
+    <steps>
+        <btxn from="DocumentSource" to="DocumentRepository" txnId="t1" handler="SoapMessaging"/>
+        <send id="soap_input" desc="Provide and Register Set-b (one Document)" from="DocumentSource" to="DocumentRepository" txnId="t1">
+            <input name="soap_message" source="$DocRepo_Template_out" />
+            <input name="http_headers" source="$soap_header" />
+            <input name="soap_attachments" source="$soap_attachments" />
+            <config name="soap.version">1.2</config>
+        </send>
+        <receive id="soap_output1" desc="Send response" from="DocumentRepository" to="DocumentSource" txnId="t1">
+            <config name="soap.version">1.2</config>
+        </receive>
+        <etxn txnId="t1"/>
+        
+        <verify handler="XSDValidator" desc="Validate first request against the XDS.b DocumentRepository Schema">
+            <input name="xmldocument">$soap_output1{soap_content}</input>
+            <input name="xsddocument" source="$XDSb_DocumentRepository"/>
+        </verify>
+    </steps>
+</testcase>

--- a/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentSource-IHE-ProvideAndRegister.xml
+++ b/gitb-ui/repository/test-suites/IHE_XDSb_SharingOfDocument/testcases/DocumentSource-IHE-ProvideAndRegister.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testcase id="DocumentSource-IHE-ProvideAndRegister" xmlns="http://www.gitb.com/tdl/v1/" xmlns:gitb="http://www.gitb.com/core/v1/">
+    <metadata>
+        <gitb:name>DocumentSource-IHE-ProvideAndRegister</gitb:name>
+        <gitb:type>CONFORMANCE</gitb:type>
+        <gitb:version>0.1</gitb:version>
+        <gitb:description>This test scenario tests the Document Source. IHE XDS.b ITI-41 Provide and Register Set-b</gitb:description>
+    </metadata>
+    <namespaces>
+    </namespaces>
+    <imports>
+        <artifact type="schema" encoding="UTF-8" name="XDSb_DocumentRepository">IHE_XDSb_SharingOfDocument/artifacts/IHE/XDS/XDS.b_DocumentRepository.xsd</artifact>
+        <artifact type="object" encoding="UTF-8" name="DocRepo_Template">IHE_XDSb_SharingOfDocument/artifacts/IHE/ihe-docrepo-template.xml</artifact>
+    </imports>
+    <actors>
+        <gitb:actor id="DocumentSource" name="DocumentSource" role="SUT" />
+        <gitb:actor id="DocumentRepository" name="DocumentRepository" role="SIMULATED">
+            <gitb:endpoint name="soap">
+                <gitb:config name="patient.id">9be1413171a8492^^^&amp;1.3.6.1.4.1.21367.2005.13.20.1000&amp;ISO</gitb:config>
+            </gitb:endpoint>
+        </gitb:actor>
+    </actors>
+    <variables>
+        <var name="soap_output1" type="map"/>
+        <var name="soap_output2" type="map"/>
+        <var name="soap_input1" type="map"/>
+        <var name="soap_input2" type="map"/>
+    </variables>
+    <steps>
+        <btxn from="DocumentSource" to="DocumentRepository" txnId="t2" handler="SoapMessaging"/>
+        <receive id="soap_output1" desc="Provide and Register Set-b (one Document)" from="DocumentSource" to="DocumentRepository" txnId="t2">
+            <config name="soap.version">1.2</config>
+        </receive>
+        <send id="soap_input1" desc="Send response" from="DocumentRepository" to="DocumentSource" txnId="t2">
+            <input name="soap_message" source="$DocRepo_Template" />
+            <config name="soap.version">1.2</config>
+        </send>
+        <etxn txnId="t2"/> 
+
+        <verify handler="NumberValidator" desc="Validate number of attachments received">
+            <input name="actualnumber">$soap_output1{soap_attachments_size}</input>
+            <input name="expectednumber">1</input>
+        </verify>
+
+        <verify handler="XDSMetadataValidator" desc="Validate first request with the remote IHE Gazelle XDS Metadata Validator">
+            <input name="xmldocument">$soap_output1{soap_content}</input>
+            <input name="validatorname">"IHE XDR ITI-41 Provide and Register Set-b – request"</input>
+        </verify>
+
+        <btxn from="DocumentSource" to="DocumentRepository" txnId="t1" handler="SoapMessaging"/>
+        <receive id="soap_output2" desc="Provide and Register Set-b (Two Documents)" from="DocumentSource" to="DocumentRepository" txnId="t1" >
+            <config name="soap.version">1.2</config>
+        </receive>
+        <send id="soap_input2" desc="Send response" from="DocumentRepository" to="DocumentSource" txnId="t1">
+            <input name="soap_message" source="$DocRepo_Template" />
+            <config name="soap.version">1.2</config>
+        </send>
+        <etxn txnId="t1"/>
+        
+        <verify handler="NumberValidator" desc="Validate number of attachments received">
+            <input name="actualnumber">$soap_output2{soap_attachments_size}</input>
+            <input name="expectednumber">2</input>
+        </verify>        
+
+    </steps>
+</testcase>

--- a/gitb-validator-ihe/pom.xml
+++ b/gitb-validator-ihe/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>GITB</artifactId>
+        <groupId>com.gitb</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <packaging>war</packaging>
+    <modelVersion>4.0.0</modelVersion>
+    
+    <artifactId>gitb-validator-ihe</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>9.2.2.v20140723</version>
+                <configuration>
+                    <httpConnector>
+                        <port>9091</port>
+                    </httpConnector>
+                    <jvmArgs>-Dorg.eclipse.jetty.annotations.maxWait=180</jvmArgs>
+                    <contextXml>src/main/webapp/WEB-INF/jetty-context.xml</contextXml>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.gitb</groupId>
+            <artifactId>gitb-validators</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>2.2.8</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/gitb-validator-ihe/src/main/java/com/gitb/vs/impl/ValidationServiceImpl.java
+++ b/gitb-validator-ihe/src/main/java/com/gitb/vs/impl/ValidationServiceImpl.java
@@ -1,0 +1,325 @@
+package com.gitb.vs.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+import javax.jws.WebParam;
+import javax.jws.WebService;
+import javax.jws.soap.SOAPBinding;
+import javax.ws.rs.core.MediaType;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPBody;
+import javax.xml.soap.SOAPBodyElement;
+import javax.xml.soap.SOAPConnection;
+import javax.xml.soap.SOAPConnectionFactory;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPElement;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFactory;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.ws.soap.Addressing;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import com.gitb.core.AnyContent;
+import com.gitb.core.ErrorCode;
+import com.gitb.core.ValidationModule;
+import com.gitb.core.ValueEmbeddingEnumeration;
+import com.gitb.exceptions.GITBEngineInternalError;
+import com.gitb.tr.TAR;
+import com.gitb.tr.TestAssertionGroupReportsType;
+import com.gitb.tr.TestResultType;
+import com.gitb.types.DataType;
+import com.gitb.types.ObjectType;
+import com.gitb.types.StringType;
+import com.gitb.utils.ErrorUtils;
+import com.gitb.utils.XMLDateTimeUtils;
+import com.gitb.utils.XMLUtils;
+import com.gitb.vs.GetModuleDefinitionResponse;
+import com.gitb.vs.ValidateRequest;
+import com.gitb.vs.ValidationResponse;
+import com.gitb.vs.ValidationService;
+import com.sun.jersey.api.client.Client;
+import com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl;
+import com.sun.org.apache.xpath.internal.jaxp.XPathImpl;
+
+/**
+ * Created by Roch Bertucat
+ */
+@Addressing(enabled = true, required = true)
+@SOAPBinding(parameterStyle = SOAPBinding.ParameterStyle.BARE)
+@WebService(
+        name = "ValidationService",
+        serviceName = "ValidationService",
+        targetNamespace = "http://www.gitb.com/vs/v1/")
+public class ValidationServiceImpl implements ValidationService {
+    private static final String VALIDATOR_MODULE_DEFINITION_FILENAME = "ihe-gazelle-xdsmetadata-validator-definition.xml";
+
+    private static final String WELLFORMED_XML_ITEM_NAME = "WELL FORMED XML";
+    private static final String VALID_XSD_ITEM_NAME = "VALID XSD";
+    private static final String VALID_MODEL_ITEM_NAME = "VALID MODEL";
+    private static final String VALIDATED_XML_ITEM_NAME = "VALIDATED XML";
+    private static final String SOAP_REQUEST_ITEM_NAME = "SOAP REQUEST";
+    private static final String SOAP_RESPONSE_ITEM_NAME = "SOAP RESPONSE";
+    private static final String PASSED = "PASSED";
+
+    private static final String VALIDATOR_MODULE_XML_DOCUMENT_PARAM = "xmldocument";
+    private static final String VALIDATOR_MODULE_VALIDATOR_NAME_PARAM = "validatorname";
+
+    private static final String GAZELLE_XDS_METADATA_ENDPOINT = "http://131.254.209.20:8080/XDStarClient-XDStarClient-ejb/XDSMetadataValidatorWS";
+
+    private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
+
+    @Override
+    public GetModuleDefinitionResponse getModuleDefinition(@WebParam(
+            name = "GetModuleDefinitionRequest",
+            targetNamespace = "http://www.gitb.com/vs/v1/",
+            partName = "parameters") com.gitb.vs.Void parameters) {
+        try {
+            ValidationModule validationModule = null;
+
+            InputStream resource = getClass().getResourceAsStream(VALIDATOR_MODULE_DEFINITION_FILENAME);
+
+            if (resource != null) {
+                validationModule = XMLUtils.unmarshal(ValidationModule.class, new StreamSource(resource));
+            }
+
+            if (validationModule == null) {
+                throw new IllegalStateException("Could not find the module definition.");
+            }
+
+            GetModuleDefinitionResponse response = new GetModuleDefinitionResponse();
+            response.setModule(validationModule);
+
+            return response;
+
+        } catch (Exception e) {
+            throw new GITBEngineInternalError(ErrorUtils.errorInfo(ErrorCode.INTERNAL_ERROR,
+                    "Could not read the module definition."), e);
+        }
+    }
+
+    @Override
+    public ValidationResponse validate(@WebParam(
+            name = "ValidateRequest",
+            targetNamespace = "http://www.gitb.com/vs/v1/",
+            partName = "parameters") ValidateRequest parameters) {
+
+        String xmlDocument = getInputParameter(parameters.getInput(), VALIDATOR_MODULE_XML_DOCUMENT_PARAM);
+        String validatorName = getInputParameter(parameters.getInput(), VALIDATOR_MODULE_VALIDATOR_NAME_PARAM);
+
+        if (xmlDocument == null) {
+            throw new GITBEngineInternalError(ErrorUtils.errorInfo(ErrorCode.MISSING_CONFIGURATION,
+                    "XML Document parameter is required."));
+        }
+
+        if (validatorName == null) {
+            throw new GITBEngineInternalError(ErrorUtils.errorInfo(ErrorCode.MISSING_CONFIGURATION,
+                    "Validator Name parameter is required."));
+        }
+
+        // encode
+        String base64 = Base64.encodeBase64String(xmlDocument.getBytes());
+
+        ObjectType requestObject = null;
+        ObjectType responseObject = null;
+        try {
+            // create SOAP message
+            MessageFactory mf = MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL);
+            SOAPMessage message = mf.createMessage();
+            SOAPBody body = message.getSOAPBody();
+            SOAPFactory soapFactory = SOAPFactory.newInstance();
+
+            // call validateXDStarMetadataB64 service
+            SOAPBodyElement bodyElement = body.addBodyElement(soapFactory.createName("validateXDStarMetadataB64",
+                    "tns", "http://ws.mb.validator.gazelle.ihe.net"));
+
+            // base64ObjectToValidate
+            SOAPElement base64Element = bodyElement.addChildElement(soapFactory.createName("base64ObjectToValidate"));
+            base64Element.addTextNode(base64);
+
+            // arg1
+            SOAPElement arg1Element = bodyElement.addChildElement(soapFactory.createName("arg1"));
+            arg1Element.addTextNode(validatorName);
+
+            // wrap request
+            requestObject = new ObjectType(body);
+
+            logger.debug("Constructed soap message to be sent to the validator");
+
+            // call
+            SOAPConnectionFactory soapConnectionFactory = SOAPConnectionFactory.newInstance();
+            SOAPConnection connection = soapConnectionFactory.createConnection();
+            SOAPMessage response = connection.call(message, new URL(GAZELLE_XDS_METADATA_ENDPOINT));
+
+            logger.debug("Sent soap message to: " + GAZELLE_XDS_METADATA_ENDPOINT);
+
+            // wrap response after unescaping XML
+            responseObject = new ObjectType(response.getSOAPBody());
+            responseObject.deserialize(StringEscapeUtils.unescapeXml(responseObject.toString()).getBytes());
+
+        } catch (SOAPException e) {
+            throw new GITBEngineInternalError(e);
+        } catch (MalformedURLException e) {
+            throw new GITBEngineInternalError(e);
+        }
+
+        ValidationResponse response = new ValidationResponse();
+        try {
+            // create the validation report
+            response.setReport(buildValidationReport(xmlDocument, requestObject, responseObject));
+        } catch (Exception e) {
+            throw new GITBEngineInternalError(ErrorUtils.errorInfo(ErrorCode.INTERNAL_ERROR,
+                    "An error occurred while building the validation report"), e);
+        }
+
+        return response;
+    }
+
+    private TAR buildValidationReport(String xml, ObjectType request, ObjectType response) throws IOException,
+            SAXException {
+
+        // check response
+        String wellFormed = getWellFormed(response);
+        String validXSD = getValidXSD(response);
+        String validModel = getValidModel(response);
+
+        TAR tar = new TAR();
+        tar.setResult(wellFormed.equals(PASSED) && validXSD.equals(PASSED) && validModel.equals(PASSED) ? TestResultType.SUCCESS
+                : TestResultType.FAILURE);
+        tar.setReports(new TestAssertionGroupReportsType());
+        try {
+            tar.setDate(XMLDateTimeUtils.getXMLGregorianCalendarDateTime());
+        } catch (DatatypeConfigurationException e) {
+            throw new GITBEngineInternalError(ErrorUtils.errorInfo(ErrorCode.INTERNAL_ERROR,
+                    "Exception while creating XMLGregorianCalendar"), e);
+        }
+
+        AnyContent attachment = new AnyContent();
+        attachment.setType(DataType.MAP_DATA_TYPE);
+
+        AnyContent wellFormedAttachment = new AnyContent();
+        wellFormedAttachment.setName(WELLFORMED_XML_ITEM_NAME);
+        wellFormedAttachment.setValue(wellFormed);
+        wellFormedAttachment.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        wellFormedAttachment.setType(DataType.STRING_DATA_TYPE);
+        attachment.getItem().add(wellFormedAttachment);
+
+        AnyContent validXSDAttachment = new AnyContent();
+        validXSDAttachment.setName(VALID_XSD_ITEM_NAME);
+        validXSDAttachment.setValue(validXSD);
+        validXSDAttachment.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        validXSDAttachment.setType(DataType.STRING_DATA_TYPE);
+        attachment.getItem().add(validXSDAttachment);
+
+        AnyContent validModelAttachment = new AnyContent();
+        validModelAttachment.setName(VALID_MODEL_ITEM_NAME);
+        validModelAttachment.setValue(validModel);
+        validModelAttachment.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        validModelAttachment.setType(DataType.STRING_DATA_TYPE);
+        attachment.getItem().add(validModelAttachment);
+
+        AnyContent xmlAttachment = new AnyContent();
+        xmlAttachment.setName(VALIDATED_XML_ITEM_NAME);
+        xmlAttachment.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        xmlAttachment.setType(DataType.OBJECT_DATA_TYPE);
+        xmlAttachment.setValue(xml);
+        attachment.getItem().add(xmlAttachment);
+
+        AnyContent requestAttachment = new AnyContent();
+        requestAttachment.setName(SOAP_REQUEST_ITEM_NAME);
+        xmlAttachment.setType(DataType.OBJECT_DATA_TYPE);
+        requestAttachment.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        requestAttachment.setValue(request.toString());
+        attachment.getItem().add(requestAttachment);
+
+        AnyContent responseAttachment = new AnyContent();
+        responseAttachment.setName(SOAP_RESPONSE_ITEM_NAME);
+        xmlAttachment.setType(DataType.OBJECT_DATA_TYPE);
+        responseAttachment.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        responseAttachment.setValue(response.toString());
+        attachment.getItem().add(responseAttachment);
+
+        tar.setName("Gazelle XDS Metadata Validation");
+        tar.setReports(new TestAssertionGroupReportsType());
+        tar.setContext(attachment);
+
+        tar.setContext(attachment);
+
+        return tar;
+    }
+
+    private String getValidModel(ObjectType response) {
+        return getFromXPath(response, "//MDAValidation/Result/text()", DataType.STRING_DATA_TYPE);
+    }
+
+    private String getValidXSD(ObjectType response) {
+        return getFromXPath(response, "//DocumentValidXSD/Result/text()", DataType.STRING_DATA_TYPE);
+    }
+
+    private String getWellFormed(ObjectType response) {
+        return getFromXPath(response, "//DocumentWellFormed/Result/text()", DataType.STRING_DATA_TYPE);
+    }
+
+    private String getFromXPath(ObjectType object, String expression, String dt) {
+        // compile xpath expression
+        XPathImpl xPath = (XPathImpl) new XPathFactoryImpl().newXPath();
+        XPathExpression xPathExpr;
+        try {
+            xPathExpr = ((XPath) xPath).compile(expression);
+        } catch (XPathExpressionException e) {
+            throw new GITBEngineInternalError(e);
+        }
+        // process xpath
+        StringType result = (StringType) object.processXPath(xPathExpr, dt);
+        return (String) result.getValue();
+    }
+
+    private String getInputParameter(List<AnyContent> inputs, String name) {
+        String content = null;
+
+        for (AnyContent anyContent : inputs) {
+            if (anyContent.getName().equals(name)) {
+                switch (anyContent.getEmbeddingMethod()) {
+                case BASE_64:
+                    content = new String(Base64.decodeBase64(anyContent.getValue()));
+                    break;
+
+                case STRING:
+                    content = anyContent.getValue();
+                    break;
+
+                case URI:
+                    Client client = Client.create();
+                    content = client.resource(anyContent.getValue()).accept(MediaType.WILDCARD_TYPE).get(String.class);
+                    break;
+                }
+                break;
+            }
+        }
+
+        if (content == null) {
+            for (AnyContent anyContent : inputs) {
+                content = getInputParameter(anyContent.getItem(), name);
+
+                if (content != null) {
+                    break;
+                }
+            }
+        }
+
+        return content;
+    }
+}

--- a/gitb-validator-ihe/src/main/resources/ihe-gazelle-xdsmetadata-validator-definition.xml
+++ b/gitb-validator-ihe/src/main/resources/ihe-gazelle-xdsmetadata-validator-definition.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<module xmlns="http://www.gitb.com/core/v1/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        id="XDSMetadataValidator" uri="urn:com:gitb:validation:ihe:gazelle:XDSMetadataValidator"
+        xsi:type="ValidationModule" isRemote="true" serviceLocation="http://localhost:9091/service/ValidationService">
+    <metadata>
+        <name>Gazelle XDS Metadata Validation</name>
+        <version>1.0</version>
+    </metadata>
+    <inputs>
+        <param type="object" use="R" name="xmldocument" desc="XML Document to be validated" />
+        <param type="string" use="R" name="validatorname" desc="Name of the validator to invoke" />
+    </inputs>
+</module>

--- a/gitb-validator-ihe/src/main/webapp/WEB-INF/jetty-context.xml
+++ b/gitb-validator-ihe/src/main/webapp/WEB-INF/jetty-context.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+	<Call name="setAttribute">
+		<Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
+		<Arg>.*/.*jsp-api-[^/]\.jar$|./.*jsp-[^/]\.jar$|./.*taglibs[^/]*\.jar$</Arg>
+	</Call>
+</Configure>

--- a/gitb-validator-ihe/src/main/webapp/WEB-INF/sun-jaxws.xml
+++ b/gitb-validator-ihe/src/main/webapp/WEB-INF/sun-jaxws.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<endpoints xmlns="http://java.sun.com/xml/ns/jax-ws/ri/runtime"
+           version="2.0">
+    <endpoint name="ValidationService"
+              implementation="com.gitb.vs.impl.ValidationServiceImpl"
+              url-pattern="/service/ValidationService" />
+</endpoints>

--- a/gitb-validator-ihe/src/main/webapp/WEB-INF/web.xml
+++ b/gitb-validator-ihe/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+    <session-config>
+        <session-timeout>
+            30
+        </session-timeout>
+    </session-config>
+    <listener>
+        <listener-class>
+            com.sun.xml.ws.transport.http.servlet.WSServletContextListener
+        </listener-class>
+    </listener>
+    <servlet>
+        <description>GITB Compliant IHE Validator</description>
+        <display-name>ValidationService</display-name>
+        <servlet-name>ValidationService</servlet-name>
+        <servlet-class>com.sun.xml.ws.transport.http.servlet.WSServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ValidationService</servlet-name>
+        <url-pattern>/service/ValidationService</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/gitb-validators/src/main/java/com/gitb/validation/number/NumberReportHandler.java
+++ b/gitb-validators/src/main/java/com/gitb/validation/number/NumberReportHandler.java
@@ -1,0 +1,56 @@
+package com.gitb.validation.number;
+
+import com.gitb.core.AnyContent;
+import com.gitb.core.ValueEmbeddingEnumeration;
+import com.gitb.tr.TAR;
+import com.gitb.tr.TestAssertionGroupReportsType;
+import com.gitb.tr.TestResultType;
+import com.gitb.types.BooleanType;
+import com.gitb.types.DataType;
+import com.gitb.types.NumberType;
+import com.gitb.validation.common.AbstractReportHandler;
+
+/**
+ * Created by Roch Bertucat
+ */
+public class NumberReportHandler extends AbstractReportHandler {
+
+    public static final String ACTUALNUMBER_ITEM_NAME = "ACTUAL NUMBER";
+    public static final String EXPECTEDNUMBER_ITEM_NAME = "EXPECTED NUMBER";
+
+    protected NumberReportHandler(NumberType actualnumber, NumberType expectednumber, BooleanType result) {
+        super();
+
+        report.setName("Number Validation");
+        report.setReports(new TestAssertionGroupReportsType());
+
+        AnyContent attachment = new AnyContent();
+        attachment.setType(DataType.MAP_DATA_TYPE);
+
+        AnyContent xml = new AnyContent();
+        xml.setName(ACTUALNUMBER_ITEM_NAME);
+        xml.setType(DataType.NUMBER_DATA_TYPE);
+        xml.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        xml.setValue(new String(actualnumber.serializeByDefaultEncoding()));
+        attachment.getItem().add(xml);
+
+        AnyContent schema = new AnyContent();
+        schema.setEmbeddingMethod(ValueEmbeddingEnumeration.STRING);
+        schema.setType(DataType.NUMBER_DATA_TYPE);
+        schema.setName(EXPECTEDNUMBER_ITEM_NAME);
+        schema.setValue(new String(expectednumber.serializeByDefaultEncoding()));
+        attachment.getItem().add(schema);
+
+        if ((boolean) result.getValue()) {
+            report.setResult(TestResultType.SUCCESS);
+        } else {
+            report.setResult(TestResultType.FAILURE);
+        }
+        report.setContext(attachment);
+    }
+
+    @Override
+    public TAR createReport() {
+        return report;
+    }
+}

--- a/gitb-validators/src/main/java/com/gitb/validation/number/NumberValidator.java
+++ b/gitb-validators/src/main/java/com/gitb/validation/number/NumberValidator.java
@@ -1,0 +1,43 @@
+package com.gitb.validation.number;
+
+import java.util.List;
+import java.util.Map;
+
+import org.kohsuke.MetaInfServices;
+
+import com.gitb.core.Configuration;
+import com.gitb.tr.TestStepReportType;
+import com.gitb.types.BooleanType;
+import com.gitb.types.DataType;
+import com.gitb.types.NumberType;
+import com.gitb.validation.IValidationHandler;
+import com.gitb.validation.common.AbstractValidator;
+
+/**
+ * Created by Roch Bertucat
+ */
+@MetaInfServices(IValidationHandler.class)
+public class NumberValidator extends AbstractValidator {
+
+    private final String ACTUAL_NUMBER_ARGUMENT_NAME = "actualnumber";
+    private final String EXPECTED_NUMBER_ARGUMENT_NAME = "expectednumber";
+
+    private final String MODULE_DEFINITION_XML = "/number-validator-definition.xml";
+
+    public NumberValidator() {
+        this.validatorDefinition = readModuleDefinition(MODULE_DEFINITION_XML);
+    }
+
+    @Override
+    public TestStepReportType validate(List<Configuration> configurations, Map<String, DataType> inputs) {
+        NumberType actualnumber = (NumberType) inputs.get(ACTUAL_NUMBER_ARGUMENT_NAME);
+        NumberType expectednumber = (NumberType) inputs.get(EXPECTED_NUMBER_ARGUMENT_NAME);
+
+        // process xpath
+        BooleanType result = new BooleanType(actualnumber.doubleValue() == expectednumber.doubleValue());
+
+        // return report
+        NumberReportHandler handler = new NumberReportHandler(actualnumber, expectednumber, result);
+        return handler.createReport();
+    }
+}

--- a/gitb-validators/src/main/resources/number-validator-definition.xml
+++ b/gitb-validators/src/main/resources/number-validator-definition.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<module xmlns="http://www.gitb.com/core/v1/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        id="NumberValidator" uri="urn:com:gitb:validation:NumberValidator" xsi:type="ValidationModule">
+    <metadata>
+        <name>Number Validator</name>
+        <version>1.0</version>
+    </metadata>
+    <inputs>
+        <param type="number" use="R" name="actualnumber" desc="Number to verify" />
+        <param type="number" use="R" name="expectednumber" desc="Number expected to have" />
+    </inputs>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 	    <module>gitb-remote-modules</module>
 	    <module>gitb-test-resources</module>
 	    <module>gitb-testbed-service</module>
+        <module>gitb-validator-ihe</module>
 	    <module>gitb-validator-validex</module>
 	    <module>gitb-validators</module>
     </modules>


### PR DESCRIPTION
## Content of the pull request

This pull request includes the following changes:
- Added a remote module validator for the IHE Gazelle XDSMetadata web service
- Added a NumberValidator to compare two integers
- Improved the existing SOAP Handler to support attachments
- Added a basic IHE TestSuite to cover the interactions between DocumentSource and DocumentRepository that leverages the previous changes
## Explanation of the Test Suite

The TestSuite contains 2 Test cases.
### DocumentRepository-IHE-ProvideAndRegister

The SUT is the DocumentRepository. We use the NIST repository available here: http://ihexds.nist.gov:12090/tf6/services/xdsrepositoryb?wsdl. It can be configured in GITB with the following values:

| Parameter | Value |
| --- | --- |
| network.host | ihexds.nist.gov |
| network.port | 12090 |
| http.uri | tf6/services/xdsrepositoryb |
### DocumentSource-IHE-ProvideAndRegister

The SUT is the DocumentSource, so, you'll need a client that can send a SOAP request with attachments to the simulated DocumentRepository.
